### PR TITLE
feat: 日報自動生成エンジン + 送信サービス

### DIFF
--- a/backend/internal/sender/email.go
+++ b/backend/internal/sender/email.go
@@ -1,0 +1,48 @@
+package sender
+
+import (
+	"context"
+	"fmt"
+	"net/smtp"
+)
+
+type EmailSender struct {
+	host     string
+	port     int
+	user     string
+	password string
+	from     string
+}
+
+func NewEmail(host string, port int, user, password, from string) *EmailSender {
+	return &EmailSender{
+		host:     host,
+		port:     port,
+		user:     user,
+		password: password,
+		from:     from,
+	}
+}
+
+func (e *EmailSender) Type() string {
+	return "email"
+}
+
+func (e *EmailSender) Send(_ context.Context, to, subject, body string) error {
+	addr := fmt.Sprintf("%s:%d", e.host, e.port)
+
+	msg := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s",
+		e.from, to, subject, body,
+	)
+
+	var auth smtp.Auth
+	if e.user != "" {
+		auth = smtp.PlainAuth("", e.user, e.password, e.host)
+	}
+
+	if err := smtp.SendMail(addr, auth, e.from, []string{to}, []byte(msg)); err != nil {
+		return fmt.Errorf("failed to send email: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/sender/sender.go
+++ b/backend/internal/sender/sender.go
@@ -1,0 +1,37 @@
+package sender
+
+import (
+	"context"
+	"fmt"
+)
+
+type Sender interface {
+	Send(ctx context.Context, to, subject, body string) error
+	Type() string
+}
+
+type Config struct {
+	SlackWebhookURL string
+	SMTPHost        string
+	SMTPPort        int
+	SMTPUser        string
+	SMTPPassword    string
+	FromEmail       string
+}
+
+type Service struct {
+	senders []Sender
+}
+
+func NewService(senders ...Sender) *Service {
+	return &Service{senders: senders}
+}
+
+func (s *Service) Send(ctx context.Context, senderType, to, subject, body string) error {
+	for _, sender := range s.senders {
+		if sender.Type() == senderType {
+			return sender.Send(ctx, to, subject, body)
+		}
+	}
+	return fmt.Errorf("unknown sender type: %s", senderType)
+}

--- a/backend/internal/sender/sender_test.go
+++ b/backend/internal/sender/sender_test.go
@@ -1,0 +1,89 @@
+package sender
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSlackSender_Send(t *testing.T) {
+	var receivedPayload map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedPayload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sender := NewSlack(server.URL, server.Client())
+	err := sender.Send(context.Background(), "#general", "日報", "テスト内容")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedPayload["channel"] != "#general" {
+		t.Errorf("expected channel #general, got %s", receivedPayload["channel"])
+	}
+
+	if receivedPayload["text"] == "" {
+		t.Error("expected non-empty text")
+	}
+}
+
+func TestSlackSender_Send_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := w.Write([]byte("error")); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	sender := NewSlack(server.URL, server.Client())
+	err := sender.Send(context.Background(), "#general", "日報", "テスト")
+	if err == nil {
+		t.Error("expected error for 500 response")
+	}
+}
+
+func TestService_Send(t *testing.T) {
+	called := false
+	mock := &mockSender{
+		typeName: "test",
+		sendFn: func(_ context.Context, _, _, _ string) error {
+			called = true
+			return nil
+		},
+	}
+
+	svc := NewService(mock)
+	err := svc.Send(context.Background(), "test", "to", "subject", "body")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected sender to be called")
+	}
+}
+
+func TestService_Send_UnknownType(t *testing.T) {
+	svc := NewService()
+	err := svc.Send(context.Background(), "unknown", "to", "subject", "body")
+	if err == nil {
+		t.Error("expected error for unknown sender type")
+	}
+}
+
+type mockSender struct {
+	typeName string
+	sendFn   func(ctx context.Context, to, subject, body string) error
+}
+
+func (m *mockSender) Type() string { return m.typeName }
+func (m *mockSender) Send(ctx context.Context, to, subject, body string) error {
+	return m.sendFn(ctx, to, subject, body)
+}

--- a/backend/internal/sender/slack.go
+++ b/backend/internal/sender/slack.go
@@ -1,0 +1,57 @@
+package sender
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type SlackSender struct {
+	webhookURL string
+	client     *http.Client
+}
+
+func NewSlack(webhookURL string, client *http.Client) *SlackSender {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &SlackSender{webhookURL: webhookURL, client: client}
+}
+
+func (s *SlackSender) Type() string {
+	return "slack"
+}
+
+func (s *SlackSender) Send(ctx context.Context, to, subject, body string) error {
+	payload := map[string]string{
+		"channel": to,
+		"text":    fmt.Sprintf("*%s*\n\n%s", subject, body),
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal slack payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.webhookURL, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("failed to create slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send slack message: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("slack returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Slack Webhook / SMTP Email による送信サービス
- プラガブルなSenderインターフェース設計
- 4テスト（Slack送信、エラーハンドリング、Service層、未知タイプ）

## Test plan
- [x] Slack送信テスト（モックHTTPサーバー）
- [x] エラーレスポンステスト
- [x] Serviceディスパッチテスト
- [x] go test -race 全パス

Closes #3