### PR TITLE
feat: 週報・月報自動要約生成

### DIFF
--- a/backend/internal/summary/config.go
+++ b/backend/internal/summary/config.go
@@ -1,0 +1,15 @@
+package summary
+
+type SummaryConfig struct {
+	FocusTopics   []string `json:"focus_topics"`
+	ExcludeTopics []string `json:"exclude_topics"`
+	MaxLength     int      `json:"max_length"`
+	DetailLevel   string   `json:"detail_level"`
+}
+
+func DefaultConfig() SummaryConfig {
+	return SummaryConfig{
+		MaxLength:   1500,
+		DetailLevel: "standard",
+	}
+}

--- a/backend/internal/summary/service.go
+++ b/backend/internal/summary/service.go
@@ -1,0 +1,85 @@
+package summary
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/akaitigo/shigoto-flow/backend/internal/model"
+	"github.com/akaitigo/shigoto-flow/backend/internal/repository"
+)
+
+type Service struct {
+	repo       *repository.Repository
+	summarizer *Summarizer
+}
+
+func NewService(repo *repository.Repository, summarizer *Summarizer) *Service {
+	return &Service{repo: repo, summarizer: summarizer}
+}
+
+func (s *Service) GenerateWeeklySummary(ctx context.Context, userID string, weekStart time.Time) (string, error) {
+	weekEnd := weekStart.AddDate(0, 0, 7)
+
+	reports, err := s.repo.ListReportsByUser(ctx, userID, model.ReportTypeDaily, 7, 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch daily reports: %w", err)
+	}
+
+	var dailyContents []string
+	for _, r := range reports {
+		if r.Date.After(weekStart) && r.Date.Before(weekEnd) {
+			dailyContents = append(dailyContents, r.Content)
+		}
+	}
+
+	if len(dailyContents) == 0 {
+		return "", fmt.Errorf("no daily reports found for the specified week")
+	}
+
+	return s.summarizer.Summarize(ctx, SummarizeInput{
+		Reports:    dailyContents,
+		ReportType: "日報",
+		Period:     "週報",
+	})
+}
+
+func (s *Service) GenerateMonthlySummary(ctx context.Context, userID string, month time.Time) (string, error) {
+	reports, err := s.repo.ListReportsByUser(ctx, userID, model.ReportTypeWeekly, 5, 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch weekly reports: %w", err)
+	}
+
+	monthStart := time.Date(month.Year(), month.Month(), 1, 0, 0, 0, 0, month.Location())
+	monthEnd := monthStart.AddDate(0, 1, 0)
+
+	var weeklyContents []string
+	for _, r := range reports {
+		if r.Date.After(monthStart) && r.Date.Before(monthEnd) {
+			weeklyContents = append(weeklyContents, r.Content)
+		}
+	}
+
+	if len(weeklyContents) == 0 {
+		dailyReports, err := s.repo.ListReportsByUser(ctx, userID, model.ReportTypeDaily, 31, 0)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch daily reports: %w", err)
+		}
+
+		for _, r := range dailyReports {
+			if r.Date.After(monthStart) && r.Date.Before(monthEnd) {
+				weeklyContents = append(weeklyContents, r.Content)
+			}
+		}
+	}
+
+	if len(weeklyContents) == 0 {
+		return "", fmt.Errorf("no reports found for the specified month")
+	}
+
+	return s.summarizer.Summarize(ctx, SummarizeInput{
+		Reports:    weeklyContents,
+		ReportType: "週報",
+		Period:     "月報",
+	})
+}

--- a/backend/internal/summary/service_test.go
+++ b/backend/internal/summary/service_test.go
@@ -1,0 +1,37 @@
+package summary
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPrompt_WithConfig(t *testing.T) {
+	input := SummarizeInput{
+		Reports:    []string{"日報内容1", "日報内容2", "日報内容3"},
+		ReportType: "日報",
+		Period:     "週報",
+	}
+
+	prompt := buildPrompt(input)
+
+	if !strings.Contains(prompt, "日報") {
+		t.Error("expected prompt to contain report type")
+	}
+	if !strings.Contains(prompt, "週報") {
+		t.Error("expected prompt to contain target period")
+	}
+	if strings.Count(prompt, "レポート") != 3 {
+		t.Errorf("expected 3 report sections, got %d", strings.Count(prompt, "レポート"))
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.MaxLength != 1500 {
+		t.Errorf("expected max length 1500, got %d", cfg.MaxLength)
+	}
+	if cfg.DetailLevel != "standard" {
+		t.Errorf("expected detail level standard, got %s", cfg.DetailLevel)
+	}
+}


### PR DESCRIPTION
## Summary
- 週報生成: 日報データからClaude APIで要約
- 月報生成: 週報（なければ日報）から要約
- 要約設定（重点項目、除外項目、長さ、詳細度）

## Test plan
- [x] プロンプト生成テスト
- [x] デフォルト設定テスト
- [x] go test -race 全パス

Closes #4