### PR TITLE
fix(security): Review Round 1 - Critical security fixes

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -31,9 +31,14 @@ func main() {
 	}
 	defer db.Close()
 
+	if cfg.TokenEncryptionKey == "" {
+		slog.Error("TOKEN_ENCRYPTION_KEY is required (32 bytes)")
+		os.Exit(1)
+	}
 	encryptor, err := auth.NewTokenEncryptor([]byte(cfg.TokenEncryptionKey))
 	if err != nil {
-		slog.Warn("token encryption disabled", "error", err)
+		slog.Error("failed to initialize token encryptor", "error", err)
+		os.Exit(1)
 	}
 
 	oauthMgr := auth.NewOAuthManager(nil)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -55,7 +55,7 @@ func Load() (*Config, error) {
 	return &Config{
 		Port:               port,
 		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:3000"),
-		TokenEncryptionKey: getEnv("TOKEN_ENCRYPTION_KEY", "01234567890123456789012345678901"),
+		TokenEncryptionKey: os.Getenv("TOKEN_ENCRYPTION_KEY"),
 		DB: DBConfig{
 			Host:     getEnv("DB_HOST", "localhost"),
 			Port:     dbPort,

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/akaitigo/shigoto-flow/backend/internal/auth"
 	"github.com/akaitigo/shigoto-flow/backend/internal/collector"
 	"github.com/akaitigo/shigoto-flow/backend/internal/config"
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
 	"github.com/akaitigo/shigoto-flow/backend/internal/repository"
 )
 
@@ -45,7 +46,7 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("GET /api/v1/auth/{provider}/callback", h.OAuthCallback)
 	mux.HandleFunc("GET /api/v1/auth/{provider}", h.OAuthRedirect)
 
-	return corsMiddleware(h.cfg.FrontendURL)(mux)
+	return corsMiddleware(h.cfg.FrontendURL)(middleware.Auth(maxBodySize(mux)))
 }
 
 func corsMiddleware(frontendURL string) func(http.Handler) http.Handler {
@@ -63,6 +64,13 @@ func corsMiddleware(frontendURL string) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func maxBodySize(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1MB
+		next.ServeHTTP(w, r)
+	})
 }
 
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {

--- a/backend/internal/handler/report.go
+++ b/backend/internal/handler/report.go
@@ -45,6 +45,12 @@ func (h *Handler) ListReports(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) GetReport(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
+		return
+	}
+
 	id := r.PathValue("id")
 	report, err := h.repo.GetReportByID(r.Context(), id)
 	if err != nil {
@@ -53,6 +59,11 @@ func (h *Handler) GetReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if report == nil {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "report not found")
+		return
+	}
+
+	if report.UserID != userID {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "report not found")
 		return
 	}
@@ -114,7 +125,19 @@ type updateReportRequest struct {
 }
 
 func (h *Handler) UpdateReport(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
+		return
+	}
+
 	id := r.PathValue("id")
+
+	report, err := h.repo.GetReportByID(r.Context(), id)
+	if err != nil || report == nil || report.UserID != userID {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "report not found")
+		return
+	}
 
 	var req updateReportRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -28,7 +28,7 @@ func Auth(next http.Handler) http.Handler {
 		if userID == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(`{"error":"authentication required","code":"UNAUTHORIZED"}`))
+			_, _ = w.Write([]byte(`{"error":"authentication required","code":"UNAUTHORIZED"}`))
 			return
 		}
 


### PR DESCRIPTION
## Summary
Review Round 1で検出されたCRITICAL/HIGH指摘の修正:

- **[CRITICAL]** 認証ミドルウェアをルーターに接続（全エンドポイント未保護だった）
- **[CRITICAL]** GetReport/UpdateReportにオーナーシップチェック追加（IDOR防止）
- **[CRITICAL]** デフォルト暗号化キーを削除（ハードコード済みの予測可能なキー）
- **[CRITICAL]** TOKEN_ENCRYPTION_KEY未設定時にサーバー起動を拒否（nilパニック防止）
- **[HIGH]** リクエストボディサイズ制限1MB（DoS防止）

## Test plan
- [x] go vet 通過
- [x] go test -race 全パス
- [x] go build 成功