### PR TITLE
fix: Review Round 2 - Auth強化 + Collector接続 + バリデーション

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/akaitigo/shigoto-flow/backend/internal/auth"
+	"github.com/akaitigo/shigoto-flow/backend/internal/collector"
 	"github.com/akaitigo/shigoto-flow/backend/internal/config"
 	"github.com/akaitigo/shigoto-flow/backend/internal/handler"
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
@@ -42,7 +43,7 @@ func main() {
 	}
 
 	oauthMgr := auth.NewOAuthManager(nil)
-	backendURL := fmt.Sprintf("http://localhost:%d", cfg.Port)
+	backendURL := cfg.BackendURL
 
 	if cfg.Google.ClientID != "" {
 		oauthMgr.RegisterProvider(model.ProviderGoogle, auth.DefaultGoogleConfig(
@@ -61,7 +62,17 @@ func main() {
 	}
 
 	repo := repository.New(db)
+
+	coll := collector.New(
+		collector.NewGoogleCalendar(nil),
+		collector.NewSlack(nil),
+		collector.NewGmail(nil),
+		collector.NewGitHub(nil),
+	)
+	collSvc := collector.NewService(repo, coll, encryptor)
+
 	h := handler.New(repo, cfg, oauthMgr, encryptor)
+	h.SetCollectorService(collSvc)
 	router := h.Routes()
 
 	srv := &http.Server{

--- a/backend/internal/collector/slack.go
+++ b/backend/internal/collector/slack.go
@@ -73,10 +73,17 @@ func (s *SlackSource) Collect(ctx context.Context, accessToken string, date time
 		return nil, fmt.Errorf("failed to decode slack response: %w", err)
 	}
 
+	if !result.OK {
+		return nil, fmt.Errorf("slack API returned ok=false")
+	}
+
 	now := time.Now()
 	var activities []model.Activity
 	for _, msg := range result.Messages.Matches {
-		tsFloat, _ := strconv.ParseFloat(msg.TS, 64)
+		tsFloat, err := strconv.ParseFloat(msg.TS, 64)
+		if err != nil {
+			continue
+		}
 		ts := time.Unix(int64(tsFloat), 0)
 
 		activities = append(activities, model.Activity{

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 type Config struct {
 	Port               int
 	FrontendURL        string
+	BackendURL         string
 	TokenEncryptionKey string
 	DB                 DBConfig
 	Google             OAuthConfig
@@ -23,12 +24,13 @@ type DBConfig struct {
 	User     string
 	Password string
 	Name     string
+	SSLMode  string
 }
 
 func (c DBConfig) DSN() string {
 	return fmt.Sprintf(
-		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-		c.Host, c.Port, c.User, c.Password, c.Name,
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		c.Host, c.Port, c.User, c.Password, c.Name, c.SSLMode,
 	)
 }
 
@@ -55,13 +57,15 @@ func Load() (*Config, error) {
 	return &Config{
 		Port:               port,
 		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:3000"),
+		BackendURL:         getEnv("BACKEND_URL", "http://localhost:8080"),
 		TokenEncryptionKey: os.Getenv("TOKEN_ENCRYPTION_KEY"),
 		DB: DBConfig{
 			Host:     getEnv("DB_HOST", "localhost"),
 			Port:     dbPort,
 			User:     getEnv("DB_USER", "shigoto"),
-			Password: getEnv("DB_PASSWORD", "shigoto_dev"),
+			Password: os.Getenv("DB_PASSWORD"),
 			Name:     getEnv("DB_NAME", "shigoto_flow"),
+			SSLMode:  getEnv("DB_SSLMODE", "disable"),
 		},
 		Google: OAuthConfig{
 			ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -55,6 +55,7 @@ func TestDBConfig_DSN(t *testing.T) {
 		User:     "testuser",
 		Password: "testpass",
 		Name:     "testdb",
+		SSLMode:  "disable",
 	}
 
 	expected := "host=localhost port=5432 user=testuser password=testpass dbname=testdb sslmode=disable"

--- a/backend/internal/handler/activity.go
+++ b/backend/internal/handler/activity.go
@@ -4,10 +4,12 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
 )
 
 func (h *Handler) ListActivities(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return
@@ -35,7 +37,7 @@ func (h *Handler) ListActivities(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) CollectActivities(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -7,16 +7,21 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 )
 
 func (h *Handler) OAuthRedirect(w http.ResponseWriter, r *http.Request) {
 	provider := model.Provider(r.PathValue("provider"))
+	if !isValidProvider(provider) {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "unsupported provider")
+		return
+	}
 
 	authURL, _, err := h.oauth.AuthURL(provider)
 	if err != nil {
 		slog.Error("failed to generate auth URL", "provider", provider, "error", err)
-		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "unsupported provider")
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "provider not configured")
 		return
 	}
 
@@ -46,9 +51,11 @@ func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID := r.Header.Get("X-User-ID")
+	// Use authenticated user from context; reject if not authenticated
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
-		userID = "anonymous"
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "must be logged in to connect a data source")
+		return
 	}
 
 	encAccessToken, err := h.encryptor.Encrypt(tokenResp.AccessToken)
@@ -84,4 +91,13 @@ func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, h.cfg.FrontendURL+"/settings?connected="+string(provider), http.StatusTemporaryRedirect)
+}
+
+func isValidProvider(p model.Provider) bool {
+	switch p {
+	case model.ProviderGoogle, model.ProviderSlack, model.ProviderGitHub, model.ProviderGmail:
+		return true
+	default:
+		return false
+	}
 }

--- a/backend/internal/handler/datasource.go
+++ b/backend/internal/handler/datasource.go
@@ -4,11 +4,12 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 )
 
 func (h *Handler) ListDataSources(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return
@@ -25,7 +26,7 @@ func (h *Handler) ListDataSources(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) DeleteDataSource(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return

--- a/backend/internal/handler/generate.go
+++ b/backend/internal/handler/generate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 	"github.com/akaitigo/shigoto-flow/backend/internal/report"
 )
@@ -18,7 +19,7 @@ type generateReportRequest struct {
 }
 
 func (h *Handler) GenerateReport(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return

--- a/backend/internal/handler/report.go
+++ b/backend/internal/handler/report.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 )
 
 func (h *Handler) ListReports(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return
@@ -45,7 +46,7 @@ func (h *Handler) ListReports(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) GetReport(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return
@@ -79,7 +80,7 @@ type createReportRequest struct {
 }
 
 func (h *Handler) CreateReport(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return
@@ -88,6 +89,11 @@ func (h *Handler) CreateReport(w http.ResponseWriter, r *http.Request) {
 	var req createReportRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		return
+	}
+
+	if !isValidReportType(req.Type) {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "type must be daily, weekly, or monthly")
 		return
 	}
 
@@ -125,7 +131,7 @@ type updateReportRequest struct {
 }
 
 func (h *Handler) UpdateReport(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return
@@ -145,6 +151,11 @@ func (h *Handler) UpdateReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.Status != "" && !isValidStatus(req.Status) {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "status must be draft, confirmed, or sent")
+		return
+	}
+
 	if err := h.repo.UpdateReportContent(r.Context(), id, req.Content, req.Status); err != nil {
 		slog.Error("failed to update report", "error", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to update report")
@@ -152,4 +163,22 @@ func (h *Handler) UpdateReport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+}
+
+func isValidReportType(t model.ReportType) bool {
+	switch t {
+	case model.ReportTypeDaily, model.ReportTypeWeekly, model.ReportTypeMonthly:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidStatus(s string) bool {
+	switch s {
+	case model.ReportStatusDraft, model.ReportStatusConfirmed, model.ReportStatusSent:
+		return true
+	default:
+		return false
+	}
 }

--- a/backend/internal/handler/template.go
+++ b/backend/internal/handler/template.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 )
 
 func (h *Handler) ListTemplates(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return
@@ -36,7 +37,7 @@ type createTemplateRequest struct {
 }
 
 func (h *Handler) CreateTemplate(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("X-User-ID")
+	userID := middleware.UserIDFromContext(r.Context())
 	if userID == "" {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
 		return

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -45,7 +45,6 @@ func UserIDFromContext(ctx context.Context) string {
 func isPublicPath(path string) bool {
 	publicPaths := []string{
 		"/api/v1/health",
-		"/api/v1/auth/",
 	}
 	for _, p := range publicPaths {
 		if strings.HasPrefix(path, p) {

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -15,8 +15,6 @@ func TestAuth_AllowsPublicPaths(t *testing.T) {
 		path string
 	}{
 		{"/api/v1/health"},
-		{"/api/v1/auth/google"},
-		{"/api/v1/auth/google/callback"},
 	}
 
 	for _, tt := range tests {
@@ -90,8 +88,8 @@ func TestIsPublicPath(t *testing.T) {
 		public bool
 	}{
 		{"/api/v1/health", true},
-		{"/api/v1/auth/google", true},
-		{"/api/v1/auth/slack/callback", true},
+		{"/api/v1/auth/google", false},
+		{"/api/v1/auth/slack/callback", false},
 		{"/api/v1/reports", false},
 		{"/api/v1/activities", false},
 		{"/api/v1/templates", false},


### PR DESCRIPTION
## Summary
Review Round 2の深掘りレビューで検出された全CRITICAL/HIGH指摘の修正。

### CRITICAL (4件修正)
- 全ハンドラーをmiddleware.UserIDFromContext()に統一（rawヘッダー直読み廃止）
- OAuthコールバックを認証必須に変更（anonymous token保存を排除）
- Collectorサービスをmain.goに接続（503応答を解消）
- ReportType/Statusのバリデーション追加（任意文字列のDB格納を防止）

### HIGH (4件修正)
- Slack API ok=falseチェック追加（エラー無音消失を防止）
- Slackタイムスタンプのパースエラー処理（1970年データ格納を防止）
- DBパスワードのデフォルト値削除
- DB SSLMode環境変数対応

## Test plan
- [x] go vet 全パス
- [x] go test -race 全パス (7パッケージ)
- [x] go build 成功
- [x] frontend lint + test 全パス

Closes: Review Round 2