### PR TITLE
fix(security): resolve CRITICAL/HIGH auth and data handling issues

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -75,6 +75,10 @@ func main() {
 	)
 	collSvc := collector.NewService(repo, coll, encryptor)
 
+	// Start periodic cleanup of expired OAuth state entries (every 5 minutes)
+	cleanupCancel := oauthMgr.StartStateCleanup(context.Background(), 5*time.Minute)
+	defer cleanupCancel()
+
 	h := handler.New(repo, cfg, oauthMgr, encryptor)
 	h.SetCollectorService(collSvc)
 	router := h.Routes()

--- a/backend/internal/auth/oauth.go
+++ b/backend/internal/auth/oauth.go
@@ -21,6 +21,7 @@ type ProviderConfig struct {
 	ClientSecret string
 	AuthURL      string
 	TokenURL     string
+	UserInfoURL  string
 	Scopes       []string
 	RedirectURL  string
 }
@@ -30,6 +31,12 @@ type TokenResponse struct {
 	RefreshToken string `json:"refresh_token"`
 	ExpiresIn    int    `json:"expires_in"`
 	TokenType    string `json:"token_type"`
+}
+
+// UserInfo holds user profile information retrieved from an OAuth provider.
+type UserInfo struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
 }
 
 type OAuthManager struct {
@@ -191,6 +198,98 @@ func (m *OAuthManager) CleanupExpiredStates() {
 	}
 }
 
+// StartStateCleanup starts a background goroutine that periodically removes
+// expired OAuth state entries. Call the returned cancel function to stop it.
+func (m *OAuthManager) StartStateCleanup(ctx context.Context, interval time.Duration) context.CancelFunc {
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.CleanupExpiredStates()
+			}
+		}
+	}()
+	return cancel
+}
+
+// FetchUserInfo retrieves user profile information from the provider's userinfo
+// endpoint using the given access token.
+func (m *OAuthManager) FetchUserInfo(ctx context.Context, provider model.Provider, accessToken string) (*UserInfo, error) {
+	cfg, ok := m.providers[provider]
+	if !ok {
+		return nil, fmt.Errorf("unknown provider: %s", provider)
+	}
+	if cfg.UserInfoURL == "" {
+		return nil, fmt.Errorf("provider %s has no userinfo URL configured", provider)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.UserInfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create userinfo request: %w", err)
+	}
+
+	switch provider {
+	case model.ProviderGitHub:
+		req.Header.Set("Authorization", "token "+accessToken)
+	default:
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch userinfo: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("userinfo request failed with %d: %s", resp.StatusCode, string(body))
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("failed to decode userinfo response: %w", err)
+	}
+
+	info := &UserInfo{}
+
+	// Parse email - different providers use different field names
+	if emailRaw, ok := raw["email"]; ok {
+		var email string
+		if err := json.Unmarshal(emailRaw, &email); err == nil {
+			info.Email = email
+		}
+	}
+
+	// Parse name - try "name" then "login" (GitHub)
+	if nameRaw, ok := raw["name"]; ok {
+		var name string
+		if err := json.Unmarshal(nameRaw, &name); err == nil {
+			info.Name = name
+		}
+	}
+	if info.Name == "" {
+		if loginRaw, ok := raw["login"]; ok {
+			var login string
+			if err := json.Unmarshal(loginRaw, &login); err == nil {
+				info.Name = login
+			}
+		}
+	}
+
+	if info.Email == "" {
+		return nil, fmt.Errorf("provider %s did not return an email address", provider)
+	}
+
+	return info, nil
+}
+
 func generateState() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
@@ -205,7 +304,11 @@ func DefaultGoogleConfig(clientID, clientSecret, redirectBase string) ProviderCo
 		ClientSecret: clientSecret,
 		AuthURL:      "https://accounts.google.com/o/oauth2/v2/auth",
 		TokenURL:     "https://oauth2.googleapis.com/token",
+		UserInfoURL:  "https://www.googleapis.com/oauth2/v2/userinfo",
 		Scopes: []string{
+			"openid",
+			"email",
+			"profile",
 			"https://www.googleapis.com/auth/calendar.readonly",
 			"https://www.googleapis.com/auth/gmail.readonly",
 		},
@@ -219,7 +322,8 @@ func DefaultSlackConfig(clientID, clientSecret, redirectBase string) ProviderCon
 		ClientSecret: clientSecret,
 		AuthURL:      "https://slack.com/oauth/v2/authorize",
 		TokenURL:     "https://slack.com/api/oauth.v2.access",
-		Scopes:       []string{"search:read", "users:read"},
+		UserInfoURL:  "https://slack.com/api/users.identity",
+		Scopes:       []string{"identity.basic", "identity.email", "search:read", "users:read"},
 		RedirectURL:  redirectBase + "/api/v1/auth/slack/callback",
 	}
 }
@@ -230,6 +334,7 @@ func DefaultGitHubConfig(clientID, clientSecret, redirectBase string) ProviderCo
 		ClientSecret: clientSecret,
 		AuthURL:      "https://github.com/login/oauth/authorize",
 		TokenURL:     "https://github.com/login/oauth/access_token",
+		UserInfoURL:  "https://api.github.com/user",
 		Scopes:       []string{"repo", "user:email"},
 		RedirectURL:  redirectBase + "/api/v1/auth/github/callback",
 	}

--- a/backend/internal/auth/oauth_test.go
+++ b/backend/internal/auth/oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 )
@@ -210,5 +211,133 @@ func TestOAuthManager_CleanupExpiredStates(t *testing.T) {
 	_, err = mgr.ValidateState(state)
 	if err != nil {
 		t.Error("recent state should not be cleaned up")
+	}
+}
+
+func TestOAuthManager_StartStateCleanup(t *testing.T) {
+	mgr := NewOAuthManager(nil)
+	mgr.RegisterProvider(model.ProviderGoogle, ProviderConfig{
+		ClientID: "test",
+		AuthURL:  "https://example.com/auth",
+	})
+
+	ctx := context.Background()
+	cancel := mgr.StartStateCleanup(ctx, 50*time.Millisecond)
+
+	// Add an expired state entry manually
+	mgr.mu.Lock()
+	mgr.states["expired-state"] = stateEntry{
+		provider:  model.ProviderGoogle,
+		createdAt: time.Now().Add(-15 * time.Minute),
+	}
+	mgr.mu.Unlock()
+
+	// Wait for the cleanup goroutine to run at least once
+	time.Sleep(150 * time.Millisecond)
+
+	mgr.mu.Lock()
+	_, exists := mgr.states["expired-state"]
+	mgr.mu.Unlock()
+
+	if exists {
+		t.Error("expired state should have been cleaned up by background goroutine")
+	}
+
+	// Stop the cleanup goroutine
+	cancel()
+}
+
+func TestOAuthManager_FetchUserInfo_Google(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer test-access-token" {
+			t.Errorf("expected Bearer test-access-token, got %s", authHeader)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"email":"user@example.com","name":"Test User"}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	mgr := NewOAuthManager(server.Client())
+	mgr.RegisterProvider(model.ProviderGoogle, ProviderConfig{
+		ClientID:    "test",
+		UserInfoURL: server.URL,
+	})
+
+	info, err := mgr.FetchUserInfo(context.Background(), model.ProviderGoogle, "test-access-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Email != "user@example.com" {
+		t.Errorf("expected user@example.com, got %s", info.Email)
+	}
+	if info.Name != "Test User" {
+		t.Errorf("expected Test User, got %s", info.Name)
+	}
+}
+
+func TestOAuthManager_FetchUserInfo_GitHub(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "token gh-token" {
+			t.Errorf("expected token gh-token, got %s", authHeader)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"email":"dev@github.com","name":"","login":"octocat"}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	mgr := NewOAuthManager(server.Client())
+	mgr.RegisterProvider(model.ProviderGitHub, ProviderConfig{
+		ClientID:    "test",
+		UserInfoURL: server.URL,
+	})
+
+	info, err := mgr.FetchUserInfo(context.Background(), model.ProviderGitHub, "gh-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Email != "dev@github.com" {
+		t.Errorf("expected dev@github.com, got %s", info.Email)
+	}
+	if info.Name != "octocat" {
+		t.Errorf("expected octocat (fallback to login), got %s", info.Name)
+	}
+}
+
+func TestOAuthManager_FetchUserInfo_NoEmail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"name":"No Email User"}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	mgr := NewOAuthManager(server.Client())
+	mgr.RegisterProvider(model.ProviderGoogle, ProviderConfig{
+		ClientID:    "test",
+		UserInfoURL: server.URL,
+	})
+
+	_, err := mgr.FetchUserInfo(context.Background(), model.ProviderGoogle, "token")
+	if err == nil {
+		t.Error("expected error when email is missing")
+	}
+}
+
+func TestOAuthManager_FetchUserInfo_NoUserInfoURL(t *testing.T) {
+	mgr := NewOAuthManager(nil)
+	mgr.RegisterProvider(model.ProviderGoogle, ProviderConfig{
+		ClientID: "test",
+	})
+
+	_, err := mgr.FetchUserInfo(context.Background(), model.ProviderGoogle, "token")
+	if err == nil {
+		t.Error("expected error when userinfo URL is not configured")
 	}
 }

--- a/backend/internal/handler/activity.go
+++ b/backend/internal/handler/activity.go
@@ -55,7 +55,7 @@ func (h *Handler) CollectActivities(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"status":    "completed",
 		"collected": result.Collected,
 		"errors":    len(result.Errors),

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -51,24 +53,46 @@ func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get or create user based on provider identity
-	// For now, generate a deterministic user ID from provider + access token hash
-	// In production, fetch user info from the provider's userinfo endpoint
-	userID := middleware.UserIDFromContext(r.Context())
-	if userID == "" {
-		// New login flow: create user from OAuth
+	// Fetch real user info from the provider's userinfo endpoint
+	userInfo, err := h.oauth.FetchUserInfo(r.Context(), provider, tokenResp.AccessToken)
+	if err != nil {
+		slog.Error("failed to fetch user info from provider", "provider", provider, "error", err)
+		writeError(w, http.StatusInternalServerError, "USERINFO_FAILED", "failed to retrieve user information from provider")
+		return
+	}
+
+	// Look up existing user by email, or create a new one
+	existingUser, err := h.repo.GetUserByEmail(r.Context(), userInfo.Email)
+	if err != nil {
+		slog.Error("failed to look up user by email", "email", userInfo.Email, "error", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to look up user")
+		return
+	}
+
+	var userID string
+	if existingUser != nil {
+		userID = existingUser.ID
+		// Update name if changed
+		if existingUser.Name != userInfo.Name && userInfo.Name != "" {
+			existingUser.Name = userInfo.Name
+			if err := h.repo.UpdateUser(r.Context(), existingUser); err != nil {
+				slog.Warn("failed to update user name", "error", err)
+			}
+		}
+	} else {
 		userID = uuid.New().String()
 		now := time.Now()
 		user := &model.User{
 			ID:        userID,
-			Email:     string(provider) + "-user@shigoto-flow.local",
-			Name:      string(provider) + " User",
+			Email:     userInfo.Email,
+			Name:      userInfo.Name,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
 		if err := h.repo.CreateUser(r.Context(), user); err != nil {
-			// User might already exist, try to continue
-			slog.Warn("failed to create user, may already exist", "error", err)
+			slog.Error("failed to create user", "error", err)
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to create user")
+			return
 		}
 	}
 
@@ -105,19 +129,55 @@ func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Issue JWT token for the user
-	jwt, err := middleware.GenerateToken([]byte(h.cfg.JWTSecret), userID, 24*time.Hour)
+	jwtToken, err := middleware.GenerateToken([]byte(h.cfg.JWTSecret), userID, 24*time.Hour)
 	if err != nil {
 		slog.Error("failed to generate JWT", "error", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate session token")
 		return
 	}
 
-	http.Redirect(w, r, h.cfg.FrontendURL+"/settings?token="+jwt+"&connected="+string(provider), http.StatusTemporaryRedirect)
+	// Set JWT as HttpOnly cookie instead of URL query parameter (RFC 6750 compliance)
+	frontendURL, parseErr := url.Parse(h.cfg.FrontendURL)
+	isSecure := parseErr == nil && frontendURL.Scheme == "https"
+	sameSite := http.SameSiteLaxMode
+	if isSecure {
+		sameSite = http.SameSiteNoneMode
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session_token",
+		Value:    jwtToken,
+		Path:     "/",
+		Domain:   cookieDomain(h.cfg.FrontendURL),
+		MaxAge:   int((24 * time.Hour).Seconds()),
+		HttpOnly: true,
+		Secure:   isSecure,
+		SameSite: sameSite,
+	})
+
+	http.Redirect(w, r, h.cfg.FrontendURL+"/settings?connected="+string(provider), http.StatusTemporaryRedirect)
 }
 
+// cookieDomain extracts the hostname from a URL for use as cookie domain.
+// Returns empty string if parsing fails (browser will use the response origin).
+func cookieDomain(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	host := u.Hostname()
+	// Don't set domain for localhost (browsers reject it)
+	if host == "localhost" || strings.HasPrefix(host, "127.") {
+		return ""
+	}
+	return host
+}
+
+// isValidProvider checks whether the given provider is supported.
+// Gmail is NOT a separate provider; it is covered by the Google provider's scopes.
 func isValidProvider(p model.Provider) bool {
 	switch p {
-	case model.ProviderGoogle, model.ProviderSlack, model.ProviderGitHub, model.ProviderGmail:
+	case model.ProviderGoogle, model.ProviderSlack, model.ProviderGitHub:
 		return true
 	default:
 		return false

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -56,6 +56,7 @@ func corsMiddleware(frontendURL string) func(http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Origin", frontendURL)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Vary", "Origin")
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.Header().Set("X-Frame-Options", "DENY")
@@ -78,7 +79,7 @@ func maxBodySize(next http.Handler) http.Handler {
 	})
 }
 
-func writeJSON(w http.ResponseWriter, status int, data interface{}) {
+func writeJSON(w http.ResponseWriter, status int, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(data); err != nil {

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -18,13 +18,12 @@ func AuthWithSecret(secret []byte) func(http.Handler) http.Handler {
 				return
 			}
 
-			authHeader := r.Header.Get("Authorization")
-			if !strings.HasPrefix(authHeader, "Bearer ") {
+			token := extractToken(r)
+			if token == "" {
 				writeUnauthorized(w)
 				return
 			}
 
-			token := strings.TrimPrefix(authHeader, "Bearer ")
 			claims, err := ValidateToken(secret, token)
 			if err != nil {
 				writeUnauthorized(w)
@@ -35,6 +34,19 @@ func AuthWithSecret(secret []byte) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// extractToken reads the JWT from the session_token cookie first,
+// then falls back to the Authorization: Bearer header.
+func extractToken(r *http.Request) string {
+	if cookie, err := r.Cookie("session_token"); err == nil && cookie.Value != "" {
+		return cookie.Value
+	}
+	authHeader := r.Header.Get("Authorization")
+	if strings.HasPrefix(authHeader, "Bearer ") {
+		return strings.TrimPrefix(authHeader, "Bearer ")
+	}
+	return ""
 }
 
 func UserIDFromContext(ctx context.Context) string {

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -118,6 +118,61 @@ func TestAuthWithSecret_RejectsInvalidSignature(t *testing.T) {
 	}
 }
 
+func TestAuthWithSecret_AcceptsValidCookieToken(t *testing.T) {
+	var gotUserID string
+	handler := AuthWithSecret(testSecret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserID = UserIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token, err := GenerateToken(testSecret, "cookie-user-456", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/reports", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if gotUserID != "cookie-user-456" {
+		t.Errorf("expected cookie-user-456, got %s", gotUserID)
+	}
+}
+
+func TestAuthWithSecret_CookieTakesPrecedenceOverHeader(t *testing.T) {
+	var gotUserID string
+	handler := AuthWithSecret(testSecret)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserID = UserIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	cookieToken, err := GenerateToken(testSecret, "cookie-user", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("failed to generate cookie token: %v", err)
+	}
+	headerToken, err := GenerateToken(testSecret, "header-user", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("failed to generate header token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/reports", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: cookieToken})
+	req.Header.Set("Authorization", "Bearer "+headerToken)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if gotUserID != "cookie-user" {
+		t.Errorf("expected cookie-user (cookie takes precedence), got %s", gotUserID)
+	}
+}
+
 func TestIsPublicPath(t *testing.T) {
 	tests := []struct {
 		path   string

--- a/backend/internal/repository/datasource.go
+++ b/backend/internal/repository/datasource.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
@@ -40,7 +41,7 @@ func (r *Repository) GetDataSource(ctx context.Context, userID string, provider 
 		&ds.AccessToken, &ds.RefreshToken, &ds.ExpiresAt,
 		&ds.CreatedAt, &ds.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/backend/internal/repository/report.go
+++ b/backend/internal/repository/report.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
@@ -35,7 +36,7 @@ func (r *Repository) GetReportByID(ctx context.Context, id string) (*model.Repor
 		&report.Content, &report.Date, &report.Status,
 		&report.CreatedAt, &report.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/backend/internal/repository/template.go
+++ b/backend/internal/repository/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
@@ -41,7 +42,7 @@ func (r *Repository) GetDefaultTemplate(ctx context.Context, userID string, repo
 		&tmpl.ID, &tmpl.UserID, &tmpl.Name, &tmpl.Type,
 		&sectionsJSON, &tmpl.IsDefault, &tmpl.CreatedAt, &tmpl.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -29,7 +30,7 @@ func (r *Repository) GetUserByID(ctx context.Context, id string) (*model.User, e
 	err := r.db.QueryRowContext(ctx, query, id).Scan(
 		&user.ID, &user.Email, &user.Name, &user.CreatedAt, &user.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -44,7 +45,7 @@ func (r *Repository) GetUserByEmail(ctx context.Context, email string) (*model.U
 	err := r.db.QueryRowContext(ctx, query, email).Scan(
 		&user.ID, &user.Email, &user.Name, &user.CreatedAt, &user.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/backend/internal/summary/summarizer.go
+++ b/backend/internal/summary/summarizer.go
@@ -31,7 +31,7 @@ func (s *Summarizer) Summarize(ctx context.Context, input SummarizeInput) (strin
 	systemPrompt := buildSystemPrompt(input)
 	userContent := buildUserContent(input)
 
-	reqBody := map[string]interface{}{
+	reqBody := map[string]any{
 		"model":      "claude-sonnet-4-20250514",
 		"max_tokens": 2048,
 		"system":     systemPrompt,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,7 @@ async function fetchAPI<T>(
 ): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     ...options,
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
       ...options.headers,


### PR DESCRIPTION
## Summary
- CRITICAL: JWT token moved from URL query param to HttpOnly cookie (RFC 6750)
- CRITICAL: Removed Gmail from valid OAuth providers (consolidated into Google)
- HIGH: Added credentials:'include' to frontend API calls + CORS credentials support
- HIGH: Implemented FetchUserInfo for Google/GitHub/Slack OAuth providers
- HIGH: Fixed err == sql.ErrNoRows to errors.Is() in 5 locations
- HIGH: Added OAuth state cleanup goroutine to prevent memory leaks

## Test plan
- [x] go build / go vet / go test all pass
- [x] 7 new test cases (Cookie auth, FetchUserInfo, StateCleanup)