### PR TITLE
fix(oauth): Slack token handling + provider-specific auth & connect/disconnect

### DIFF
--- a/backend/internal/auth/oauth.go
+++ b/backend/internal/auth/oauth.go
@@ -27,10 +27,23 @@ type ProviderConfig struct {
 }
 
 type TokenResponse struct {
+	AccessToken  string      `json:"access_token"`
+	RefreshToken string      `json:"refresh_token"`
+	ExpiresIn    int         `json:"expires_in"`
+	TokenType    string      `json:"token_type"`
+	AuthedUser   *AuthedUser `json:"authed_user,omitempty"`
+}
+
+// AuthedUser holds the user-level token returned by Slack's OAuth v2 flow.
+// Slack returns a bot token at the top level of the response and the
+// user token (needed for user-scoped API calls) nested under authed_user.
+type AuthedUser struct {
+	ID           string `json:"id"`
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 	ExpiresIn    int    `json:"expires_in"`
 	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
 }
 
 // UserInfo holds user profile information retrieved from an OAuth provider.
@@ -87,7 +100,13 @@ func (m *OAuthManager) AuthURL(provider model.Provider) (string, string, error) 
 	params.Set("response_type", "code")
 	params.Set("scope", strings.Join(cfg.Scopes, " "))
 	params.Set("state", state)
-	params.Set("access_type", "offline")
+
+	// access_type=offline is a Google-specific parameter used to request a
+	// refresh token. Sending it to other providers is unnecessary and can
+	// cause unexpected behavior, so only include it for Google.
+	if provider == model.ProviderGoogle {
+		params.Set("access_type", "offline")
+	}
 
 	return cfg.AuthURL + "?" + params.Encode(), state, nil
 }
@@ -144,6 +163,20 @@ func (m *OAuthManager) ExchangeCode(ctx context.Context, provider model.Provider
 	var tokenResp TokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
 		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	// Slack OAuth v2 returns the bot token at the top level (access_token) and
+	// the user token under authed_user.access_token. User-scoped API calls
+	// (e.g. users.identity, search.messages) require the user token, so
+	// promote it to be the effective access token for Slack.
+	if provider == model.ProviderSlack && tokenResp.AuthedUser != nil && tokenResp.AuthedUser.AccessToken != "" {
+		tokenResp.AccessToken = tokenResp.AuthedUser.AccessToken
+		if tokenResp.AuthedUser.RefreshToken != "" {
+			tokenResp.RefreshToken = tokenResp.AuthedUser.RefreshToken
+		}
+		if tokenResp.AuthedUser.ExpiresIn != 0 {
+			tokenResp.ExpiresIn = tokenResp.AuthedUser.ExpiresIn
+		}
 	}
 
 	return &tokenResp, nil
@@ -259,26 +292,42 @@ func (m *OAuthManager) FetchUserInfo(ctx context.Context, provider model.Provide
 
 	info := &UserInfo{}
 
-	// Parse email - different providers use different field names
-	if emailRaw, ok := raw["email"]; ok {
-		var email string
-		if err := json.Unmarshal(emailRaw, &email); err == nil {
-			info.Email = email
+	if provider == model.ProviderSlack {
+		// Slack's users.identity endpoint nests the profile under "user":
+		// {"ok":true,"user":{"id":..,"name":..,"email":..},"team":{...}}.
+		var slackUser struct {
+			Email string `json:"email"`
+			Name  string `json:"name"`
 		}
-	}
+		if userRaw, ok := raw["user"]; ok {
+			if err := json.Unmarshal(userRaw, &slackUser); err != nil {
+				return nil, fmt.Errorf("failed to decode slack user object: %w", err)
+			}
+		}
+		info.Email = slackUser.Email
+		info.Name = slackUser.Name
+	} else {
+		// Parse email - different providers use different field names
+		if emailRaw, ok := raw["email"]; ok {
+			var email string
+			if err := json.Unmarshal(emailRaw, &email); err == nil {
+				info.Email = email
+			}
+		}
 
-	// Parse name - try "name" then "login" (GitHub)
-	if nameRaw, ok := raw["name"]; ok {
-		var name string
-		if err := json.Unmarshal(nameRaw, &name); err == nil {
-			info.Name = name
+		// Parse name - try "name" then "login" (GitHub)
+		if nameRaw, ok := raw["name"]; ok {
+			var name string
+			if err := json.Unmarshal(nameRaw, &name); err == nil {
+				info.Name = name
+			}
 		}
-	}
-	if info.Name == "" {
-		if loginRaw, ok := raw["login"]; ok {
-			var login string
-			if err := json.Unmarshal(loginRaw, &login); err == nil {
-				info.Name = login
+		if info.Name == "" {
+			if loginRaw, ok := raw["login"]; ok {
+				var login string
+				if err := json.Unmarshal(loginRaw, &login); err == nil {
+					info.Name = login
+				}
 			}
 		}
 	}

--- a/backend/internal/auth/oauth_test.go
+++ b/backend/internal/auth/oauth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -339,5 +340,158 @@ func TestOAuthManager_FetchUserInfo_NoUserInfoURL(t *testing.T) {
 	_, err := mgr.FetchUserInfo(context.Background(), model.ProviderGoogle, "token")
 	if err == nil {
 		t.Error("expected error when userinfo URL is not configured")
+	}
+}
+
+// TestOAuthManager_AuthURL_AccessType verifies that access_type=offline is only
+// sent to Google, since it is a Google-specific parameter (issue #23).
+func TestOAuthManager_AuthURL_AccessType(t *testing.T) {
+	mgr := NewOAuthManager(nil)
+	mgr.RegisterProvider(model.ProviderGoogle, ProviderConfig{
+		ClientID: "g", AuthURL: "https://accounts.google.com/o/oauth2/v2/auth",
+	})
+	mgr.RegisterProvider(model.ProviderSlack, ProviderConfig{
+		ClientID: "s", AuthURL: "https://slack.com/oauth/v2/authorize",
+	})
+	mgr.RegisterProvider(model.ProviderGitHub, ProviderConfig{
+		ClientID: "gh", AuthURL: "https://github.com/login/oauth/authorize",
+	})
+
+	tests := []struct {
+		provider model.Provider
+		wantSent bool
+	}{
+		{model.ProviderGoogle, true},
+		{model.ProviderSlack, false},
+		{model.ProviderGitHub, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.provider), func(t *testing.T) {
+			authURL, _, err := mgr.AuthURL(tt.provider)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			u, err := url.Parse(authURL)
+			if err != nil {
+				t.Fatalf("failed to parse auth URL: %v", err)
+			}
+			got := u.Query().Get("access_type")
+			if tt.wantSent && got != "offline" {
+				t.Errorf("expected access_type=offline for %s, got %q", tt.provider, got)
+			}
+			if !tt.wantSent && got != "" {
+				t.Errorf("expected no access_type for %s, got %q", tt.provider, got)
+			}
+		})
+	}
+}
+
+// TestOAuthManager_ExchangeCode_SlackAuthedUser verifies that Slack's user
+// token (authed_user.access_token) is used rather than the top-level bot
+// token (issue #17).
+func TestOAuthManager_ExchangeCode_SlackAuthedUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{
+			"ok": true,
+			"access_token": "xoxb-bot-token",
+			"token_type": "bot",
+			"authed_user": {
+				"id": "U123",
+				"access_token": "xoxp-user-token",
+				"token_type": "user",
+				"refresh_token": "xoxp-refresh",
+				"expires_in": 43200
+			}
+		}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	mgr := NewOAuthManager(server.Client())
+	mgr.RegisterProvider(model.ProviderSlack, ProviderConfig{
+		ClientID:     "test",
+		ClientSecret: "test",
+		TokenURL:     server.URL,
+		RedirectURL:  "http://localhost/callback",
+	})
+
+	resp, err := mgr.ExchangeCode(context.Background(), model.ProviderSlack, "code")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AccessToken != "xoxp-user-token" {
+		t.Errorf("expected user token xoxp-user-token, got %s", resp.AccessToken)
+	}
+	if resp.RefreshToken != "xoxp-refresh" {
+		t.Errorf("expected user refresh token xoxp-refresh, got %s", resp.RefreshToken)
+	}
+	if resp.ExpiresIn != 43200 {
+		t.Errorf("expected expires_in 43200, got %d", resp.ExpiresIn)
+	}
+}
+
+// TestOAuthManager_ExchangeCode_GoogleKeepsTopLevel ensures the promotion of
+// authed_user only applies to Slack and does not affect other providers.
+func TestOAuthManager_ExchangeCode_GoogleKeepsTopLevel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:  "google-access",
+			RefreshToken: "google-refresh",
+			ExpiresIn:    3600,
+			TokenType:    "Bearer",
+		}); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	mgr := NewOAuthManager(server.Client())
+	mgr.RegisterProvider(model.ProviderGoogle, ProviderConfig{
+		ClientID: "test", ClientSecret: "test", TokenURL: server.URL,
+	})
+
+	resp, err := mgr.ExchangeCode(context.Background(), model.ProviderGoogle, "code")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AccessToken != "google-access" {
+		t.Errorf("expected google-access, got %s", resp.AccessToken)
+	}
+}
+
+// TestOAuthManager_FetchUserInfo_Slack verifies that the email/name are parsed
+// from Slack's nested "user" object (issue #21).
+func TestOAuthManager_FetchUserInfo_Slack(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer xoxp-user-token" {
+			t.Errorf("expected Bearer xoxp-user-token, got %s", authHeader)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":true,"user":{"id":"U123","name":"Slack User","email":"user@slack.example"},"team":{"id":"T1"}}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	mgr := NewOAuthManager(server.Client())
+	mgr.RegisterProvider(model.ProviderSlack, ProviderConfig{
+		ClientID:    "test",
+		UserInfoURL: server.URL,
+	})
+
+	info, err := mgr.FetchUserInfo(context.Background(), model.ProviderSlack, "xoxp-user-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Email != "user@slack.example" {
+		t.Errorf("expected user@slack.example, got %s", info.Email)
+	}
+	if info.Name != "Slack User" {
+		t.Errorf("expected Slack User, got %s", info.Name)
 	}
 }

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -2,15 +2,21 @@
 
 import Link from "next/link";
 import { DataSourceSettings } from "@/components/datasource-settings";
+import { deleteDataSource } from "@/lib/api";
+import { oauthConnectUrl } from "@/lib/backend";
 import type { Provider } from "@/types/report";
 
 export default function SettingsPage() {
   const handleConnect = (provider: Provider) => {
-    window.location.href = `/api/v1/auth/${provider}`;
+    // Absolute URL to the backend origin — a relative URL would resolve against
+    // the frontend origin (:3000) and 404.
+    window.location.href = oauthConnectUrl(provider);
   };
 
-  const handleDisconnect = (_provider: Provider) => {
-    void _provider;
+  const handleDisconnect = async (provider: Provider) => {
+    await deleteDataSource(provider);
+    // Reload so the datasource list reflects the disconnected state.
+    window.location.reload();
   };
 
   return (

--- a/frontend/src/lib/__tests__/backend.test.ts
+++ b/frontend/src/lib/__tests__/backend.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { BACKEND_URL, oauthConnectUrl } from "../backend";
+
+describe("oauthConnectUrl", () => {
+  it("builds an absolute backend URL for each provider", () => {
+    expect(oauthConnectUrl("google")).toBe(`${BACKEND_URL}/api/v1/auth/google`);
+    expect(oauthConnectUrl("slack")).toBe(`${BACKEND_URL}/api/v1/auth/slack`);
+    expect(oauthConnectUrl("github")).toBe(`${BACKEND_URL}/api/v1/auth/github`);
+  });
+
+  it("is absolute, not a relative path that would hit the frontend origin", () => {
+    const url = oauthConnectUrl("google");
+    expect(url.startsWith("http://") || url.startsWith("https://")).toBe(true);
+  });
+
+  it("defaults to localhost:8080 when NEXT_PUBLIC_BACKEND_URL is unset", () => {
+    expect(BACKEND_URL).toBe("http://localhost:8080");
+  });
+});

--- a/frontend/src/lib/backend.ts
+++ b/frontend/src/lib/backend.ts
@@ -1,0 +1,10 @@
+// Base origin of the Go API server. Used for full-page OAuth redirects where a
+// relative URL would incorrectly resolve against the frontend origin.
+export const BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+// oauthConnectUrl builds the absolute URL that starts the OAuth flow for the
+// given provider on the backend.
+export function oauthConnectUrl(provider: string): string {
+  return `${BACKEND_URL}/api/v1/auth/${provider}`;
+}


### PR DESCRIPTION
## 概要
OAuth 接続フローの高優先バグ群を修正。Slack 連携が本番で動作しない問題、接続/切断ボタンが機能しない問題を解消する。

## 変更内容
| Issue | 内容 |
|-------|------|
| #17 | Slack OAuth v2 のトークン交換で、トップレベルの bot トークンではなく `authed_user.access_token`（ユーザートークン）を採用。`TokenResponse` に `AuthedUser` を追加し、Slack のみユーザートークンへ昇格 |
| #21 | `FetchUserInfo` が Slack の `users.identity` ネスト構造（`{"user":{"email":...}}`）に対応。Slack はネストした `user` オブジェクトから email/name を取得 |
| #23 | Google 固有パラメータ `access_type=offline` を Google プロバイダーのみに送信 |
| #18 | 接続ボタンの相対 URL を廃止。`NEXT_PUBLIC_BACKEND_URL` を用いた絶対 URL（`oauthConnectUrl`）でバックエンドへ遷移 |
| #19 | 切断ボタンの no-op を解消し `deleteDataSource(provider)` を呼び出すよう実装 |

## テスト
- backend: Slack authed_user トークン昇格 / 非 Slack はトップレベル維持 / Slack userinfo ネスト解析 / `access_type` のプロバイダー別送信 を httptest で検証
- frontend: `oauthConnectUrl` が絶対 URL を生成することを vitest で検証
- `go test -race ./...` green / `pnpm lint && pnpm test && pnpm build` green / gofmt・goimports クリーン

## 補足
- `NEXT_PUBLIC_BACKEND_URL` はコード側でフォールバック（`http://localhost:8080`）を持つため未設定でも動作。`.env.example` への追記は専用 Issue #27 で対応する。
- 切断後の一覧更新は現状 `window.location.reload()`。データソース一覧の状態管理は #20（別 PR）で導入予定。

Fixes #17, #18, #19, #21, #23