### PR TITLE
fix(data): settings/reports data display + Gmail/summary data retrieval

### DIFF
--- a/backend/internal/collector/gmail.go
+++ b/backend/internal/collector/gmail.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -136,7 +137,7 @@ func (g *GmailSource) getMessageDetail(ctx context.Context, accessToken, message
 
 	detail := &messageDetail{
 		snippet: msg.Snippet,
-		date:    time.Now(),
+		date:    parseInternalDate(msg.InternalDate),
 	}
 
 	for _, header := range msg.Payload.Headers {
@@ -149,4 +150,15 @@ func (g *GmailSource) getMessageDetail(ctx context.Context, accessToken, message
 	}
 
 	return detail, nil
+}
+
+// parseInternalDate converts Gmail's internalDate (Unix milliseconds encoded as
+// a string) into a time.Time. It falls back to the current time when the value
+// is missing or cannot be parsed, so a malformed timestamp never drops a message.
+func parseInternalDate(internalDate string) time.Time {
+	ms, err := strconv.ParseInt(internalDate, 10, 64)
+	if err != nil {
+		return time.Now()
+	}
+	return time.UnixMilli(ms)
 }

--- a/backend/internal/collector/gmail_test.go
+++ b/backend/internal/collector/gmail_test.go
@@ -1,0 +1,55 @@
+package collector
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestParseInternalDate(t *testing.T) {
+	want := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		internalDate string
+		wantFallback bool
+		want         time.Time
+	}{
+		{
+			name:         "valid unix millis",
+			internalDate: strconv.FormatInt(want.UnixMilli(), 10),
+			want:         want,
+		},
+		{
+			name:         "empty falls back to now",
+			internalDate: "",
+			wantFallback: true,
+		},
+		{
+			name:         "non-numeric falls back to now",
+			internalDate: "not-a-number",
+			wantFallback: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseInternalDate(tt.internalDate)
+
+			if tt.wantFallback {
+				// Fallback should be close to now, never the zero value.
+				if got.IsZero() {
+					t.Error("expected fallback to current time, got zero value")
+				}
+				if time.Since(got) > time.Minute {
+					t.Errorf("expected fallback near now, got %v", got)
+				}
+				return
+			}
+
+			if !got.UTC().Equal(tt.want) {
+				t.Errorf("expected %v, got %v", tt.want, got.UTC())
+			}
+		})
+	}
+}

--- a/backend/internal/repository/report.go
+++ b/backend/internal/repository/report.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 )
@@ -54,6 +55,38 @@ func (r *Repository) ListReportsByUser(ctx context.Context, userID string, repor
 	rows, err := r.db.QueryContext(ctx, query, userID, reportType, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list reports: %w", err)
+	}
+	defer rows.Close()
+
+	var reports []model.Report
+	for rows.Next() {
+		var report model.Report
+		if err := rows.Scan(
+			&report.ID, &report.UserID, &report.Type, &report.TemplateID,
+			&report.Content, &report.Date, &report.Status,
+			&report.CreatedAt, &report.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan report: %w", err)
+		}
+		reports = append(reports, report)
+	}
+	return reports, rows.Err()
+}
+
+// ListReportsByUserAndDateRange returns all reports of the given type whose
+// date falls within [start, end). Unlike ListReportsByUser it is not capped by
+// a fixed limit, so callers can retrieve an arbitrary historical window (e.g.
+// a specific past week or month) rather than only the most recent reports.
+func (r *Repository) ListReportsByUserAndDateRange(ctx context.Context, userID string, reportType model.ReportType, start, end time.Time) ([]model.Report, error) {
+	query := `
+		SELECT id, user_id, type, template_id, content, date, status, created_at, updated_at
+		FROM reports
+		WHERE user_id = $1 AND type = $2 AND date >= $3 AND date < $4
+		ORDER BY date DESC
+	`
+	rows, err := r.db.QueryContext(ctx, query, userID, reportType, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list reports by date range: %w", err)
 	}
 	defer rows.Close()
 

--- a/backend/internal/summary/service.go
+++ b/backend/internal/summary/service.go
@@ -6,31 +6,41 @@ import (
 	"time"
 
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
-	"github.com/akaitigo/shigoto-flow/backend/internal/repository"
 )
 
-type Service struct {
-	repo       *repository.Repository
-	summarizer *Summarizer
+// reportRepository is the subset of the repository used by the summary service.
+// Using an interface keeps the service unit-testable without a live database.
+type reportRepository interface {
+	ListReportsByUserAndDateRange(ctx context.Context, userID string, reportType model.ReportType, start, end time.Time) ([]model.Report, error)
 }
 
-func NewService(repo *repository.Repository, summarizer *Summarizer) *Service {
+// summarizerClient produces a summary from a set of reports.
+type summarizerClient interface {
+	Summarize(ctx context.Context, input SummarizeInput) (string, error)
+}
+
+type Service struct {
+	repo       reportRepository
+	summarizer summarizerClient
+}
+
+func NewService(repo reportRepository, summarizer summarizerClient) *Service {
 	return &Service{repo: repo, summarizer: summarizer}
 }
 
 func (s *Service) GenerateWeeklySummary(ctx context.Context, userID string, weekStart time.Time) (string, error) {
 	weekEnd := weekStart.AddDate(0, 0, 7)
 
-	reports, err := s.repo.ListReportsByUser(ctx, userID, model.ReportTypeDaily, 7, 0)
+	// Query the exact week window so past weeks can be summarized, rather than
+	// only being able to reach the most recent handful of daily reports.
+	reports, err := s.repo.ListReportsByUserAndDateRange(ctx, userID, model.ReportTypeDaily, weekStart, weekEnd)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch daily reports: %w", err)
 	}
 
-	var dailyContents []string
+	dailyContents := make([]string, 0, len(reports))
 	for _, r := range reports {
-		if r.Date.After(weekStart) && r.Date.Before(weekEnd) {
-			dailyContents = append(dailyContents, r.Content)
-		}
+		dailyContents = append(dailyContents, r.Content)
 	}
 
 	if len(dailyContents) == 0 {
@@ -45,40 +55,36 @@ func (s *Service) GenerateWeeklySummary(ctx context.Context, userID string, week
 }
 
 func (s *Service) GenerateMonthlySummary(ctx context.Context, userID string, month time.Time) (string, error) {
-	reports, err := s.repo.ListReportsByUser(ctx, userID, model.ReportTypeWeekly, 5, 0)
+	monthStart := time.Date(month.Year(), month.Month(), 1, 0, 0, 0, 0, month.Location())
+	monthEnd := monthStart.AddDate(0, 1, 0)
+
+	reports, err := s.repo.ListReportsByUserAndDateRange(ctx, userID, model.ReportTypeWeekly, monthStart, monthEnd)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch weekly reports: %w", err)
 	}
 
-	monthStart := time.Date(month.Year(), month.Month(), 1, 0, 0, 0, 0, month.Location())
-	monthEnd := monthStart.AddDate(0, 1, 0)
-
-	var weeklyContents []string
+	contents := make([]string, 0, len(reports))
 	for _, r := range reports {
-		if r.Date.After(monthStart) && r.Date.Before(monthEnd) {
-			weeklyContents = append(weeklyContents, r.Content)
-		}
+		contents = append(contents, r.Content)
 	}
 
-	if len(weeklyContents) == 0 {
-		dailyReports, err := s.repo.ListReportsByUser(ctx, userID, model.ReportTypeDaily, 31, 0)
+	// Fall back to daily reports when no weekly reports exist for the month.
+	if len(contents) == 0 {
+		dailyReports, err := s.repo.ListReportsByUserAndDateRange(ctx, userID, model.ReportTypeDaily, monthStart, monthEnd)
 		if err != nil {
 			return "", fmt.Errorf("failed to fetch daily reports: %w", err)
 		}
-
 		for _, r := range dailyReports {
-			if r.Date.After(monthStart) && r.Date.Before(monthEnd) {
-				weeklyContents = append(weeklyContents, r.Content)
-			}
+			contents = append(contents, r.Content)
 		}
 	}
 
-	if len(weeklyContents) == 0 {
+	if len(contents) == 0 {
 		return "", fmt.Errorf("no reports found for the specified month")
 	}
 
 	return s.summarizer.Summarize(ctx, SummarizeInput{
-		Reports:    weeklyContents,
+		Reports:    contents,
 		ReportType: "週報",
 		Period:     "月報",
 	})

--- a/backend/internal/summary/service_test.go
+++ b/backend/internal/summary/service_test.go
@@ -1,9 +1,190 @@
 package summary
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 )
+
+type fakeReportRepo struct {
+	byType  map[model.ReportType][]model.Report
+	gotType model.ReportType
+	gotFrom time.Time
+	gotTo   time.Time
+	calls   int
+	err     error
+}
+
+func (f *fakeReportRepo) ListReportsByUserAndDateRange(_ context.Context, _ string, reportType model.ReportType, start, end time.Time) ([]model.Report, error) {
+	f.calls++
+	f.gotType = reportType
+	f.gotFrom = start
+	f.gotTo = end
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byType[reportType], nil
+}
+
+type fakeSummarizer struct {
+	gotInput SummarizeInput
+	result   string
+	err      error
+}
+
+func (f *fakeSummarizer) Summarize(_ context.Context, input SummarizeInput) (string, error) {
+	f.gotInput = input
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.result, nil
+}
+
+func reportsWithContent(reportType model.ReportType, contents ...string) []model.Report {
+	reports := make([]model.Report, 0, len(contents))
+	for _, c := range contents {
+		reports = append(reports, model.Report{Type: reportType, Content: c})
+	}
+	return reports
+}
+
+func TestGenerateWeeklySummary(t *testing.T) {
+	weekStart := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+
+	// More than the old hard-coded limit of 7 to prove the cap is gone.
+	contents := make([]string, 0, 10)
+	for i := 1; i <= 10; i++ {
+		contents = append(contents, fmt.Sprintf("日報%d", i))
+	}
+
+	repo := &fakeReportRepo{
+		byType: map[model.ReportType][]model.Report{
+			model.ReportTypeDaily: reportsWithContent(model.ReportTypeDaily, contents...),
+		},
+	}
+	sum := &fakeSummarizer{result: "週報サマリー"}
+	svc := NewService(repo, sum)
+
+	got, err := svc.GenerateWeeklySummary(context.Background(), "user1", weekStart)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "週報サマリー" {
+		t.Errorf("expected summarizer result, got %q", got)
+	}
+	if repo.gotType != model.ReportTypeDaily {
+		t.Errorf("expected daily reports queried, got %s", repo.gotType)
+	}
+	if !repo.gotFrom.Equal(weekStart) {
+		t.Errorf("expected range start %v, got %v", weekStart, repo.gotFrom)
+	}
+	if want := weekStart.AddDate(0, 0, 7); !repo.gotTo.Equal(want) {
+		t.Errorf("expected range end %v, got %v", want, repo.gotTo)
+	}
+	if len(sum.gotInput.Reports) != 10 {
+		t.Errorf("expected all 10 daily reports forwarded (no 7-item cap), got %d", len(sum.gotInput.Reports))
+	}
+	if sum.gotInput.Period != "週報" {
+		t.Errorf("expected period 週報, got %s", sum.gotInput.Period)
+	}
+}
+
+func TestGenerateWeeklySummary_NoReports(t *testing.T) {
+	repo := &fakeReportRepo{byType: map[model.ReportType][]model.Report{}}
+	sum := &fakeSummarizer{result: "unused"}
+	svc := NewService(repo, sum)
+
+	_, err := svc.GenerateWeeklySummary(context.Background(), "user1", time.Now())
+	if err == nil {
+		t.Error("expected error when no daily reports exist")
+	}
+	if sum.gotInput.Reports != nil {
+		t.Error("summarizer should not be called when there are no reports")
+	}
+}
+
+func TestGenerateWeeklySummary_RepoError(t *testing.T) {
+	repo := &fakeReportRepo{err: errors.New("db down")}
+	svc := NewService(repo, &fakeSummarizer{})
+
+	_, err := svc.GenerateWeeklySummary(context.Background(), "user1", time.Now())
+	if err == nil {
+		t.Error("expected error to propagate from repository")
+	}
+}
+
+func TestGenerateMonthlySummary_UsesWeekly(t *testing.T) {
+	month := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	repo := &fakeReportRepo{
+		byType: map[model.ReportType][]model.Report{
+			model.ReportTypeWeekly: reportsWithContent(model.ReportTypeWeekly, "週報1", "週報2"),
+		},
+	}
+	sum := &fakeSummarizer{result: "月報サマリー"}
+	svc := NewService(repo, sum)
+
+	got, err := svc.GenerateMonthlySummary(context.Background(), "user1", month)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "月報サマリー" {
+		t.Errorf("expected summarizer result, got %q", got)
+	}
+	monthStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	if !repo.gotFrom.Equal(monthStart) {
+		t.Errorf("expected range start %v, got %v", monthStart, repo.gotFrom)
+	}
+	if want := monthStart.AddDate(0, 1, 0); !repo.gotTo.Equal(want) {
+		t.Errorf("expected range end %v, got %v", want, repo.gotTo)
+	}
+	if len(sum.gotInput.Reports) != 2 {
+		t.Errorf("expected 2 weekly reports forwarded, got %d", len(sum.gotInput.Reports))
+	}
+	if repo.calls != 1 {
+		t.Errorf("expected a single query when weekly reports exist, got %d", repo.calls)
+	}
+}
+
+func TestGenerateMonthlySummary_FallbackToDaily(t *testing.T) {
+	month := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	repo := &fakeReportRepo{
+		byType: map[model.ReportType][]model.Report{
+			// No weekly reports; only daily reports exist for the month.
+			model.ReportTypeDaily: reportsWithContent(model.ReportTypeDaily, "日報A", "日報B", "日報C"),
+		},
+	}
+	sum := &fakeSummarizer{result: "月報(日報から)"}
+	svc := NewService(repo, sum)
+
+	got, err := svc.GenerateMonthlySummary(context.Background(), "user1", month)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "月報(日報から)" {
+		t.Errorf("unexpected result: %q", got)
+	}
+	if len(sum.gotInput.Reports) != 3 {
+		t.Errorf("expected fallback to 3 daily reports, got %d", len(sum.gotInput.Reports))
+	}
+	if repo.calls != 2 {
+		t.Errorf("expected weekly query then daily fallback (2 calls), got %d", repo.calls)
+	}
+}
+
+func TestGenerateMonthlySummary_NoReports(t *testing.T) {
+	repo := &fakeReportRepo{byType: map[model.ReportType][]model.Report{}}
+	svc := NewService(repo, &fakeSummarizer{})
+
+	_, err := svc.GenerateMonthlySummary(context.Background(), "user1", time.Now())
+	if err == nil {
+		t.Error("expected error when neither weekly nor daily reports exist")
+	}
+}
 
 func TestBuildSystemPrompt(t *testing.T) {
 	input := SummarizeInput{

--- a/frontend/src/app/__tests__/reports-page.test.tsx
+++ b/frontend/src/app/__tests__/reports-page.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  listReports: vi.fn(),
+  generateReport: vi.fn(),
+  updateReport: vi.fn(),
+}));
+
+import ReportsPage from "../reports/page";
+import { listReports, generateReport } from "@/lib/api";
+import type { Report } from "@/types/report";
+
+const mockReport: Report = {
+  id: "r1",
+  user_id: "u1",
+  type: "daily",
+  template_id: "t1",
+  content: "生成された日報の内容",
+  date: "2026-04-05",
+  status: "draft",
+  created_at: "2026-04-05T09:00:00Z",
+  updated_at: "2026-04-05T09:00:00Z",
+};
+
+describe("ReportsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listReports).mockResolvedValue([]);
+  });
+
+  it("fetches daily reports on mount", async () => {
+    render(<ReportsPage />);
+
+    await waitFor(() => expect(listReports).toHaveBeenCalledWith("daily"));
+  });
+
+  it("invokes generateReport when the generate button is clicked", async () => {
+    vi.mocked(generateReport).mockResolvedValue(mockReport);
+
+    render(<ReportsPage />);
+    await waitFor(() => expect(listReports).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "日報を生成" }));
+
+    await waitFor(() =>
+      expect(generateReport).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "daily" }),
+      ),
+    );
+  });
+
+  it("refetches when switching report type", async () => {
+    render(<ReportsPage />);
+    await waitFor(() => expect(listReports).toHaveBeenCalledWith("daily"));
+
+    fireEvent.click(screen.getByRole("button", { name: "週報" }));
+
+    await waitFor(() => expect(listReports).toHaveBeenCalledWith("weekly"));
+  });
+
+  it("renders fetched reports in the list", async () => {
+    vi.mocked(listReports).mockResolvedValue([mockReport]);
+
+    render(<ReportsPage />);
+
+    expect(await screen.findByText("2026-04-05")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/__tests__/settings-page.test.tsx
+++ b/frontend/src/app/__tests__/settings-page.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  listDataSources: vi.fn(),
+  deleteDataSource: vi.fn(),
+}));
+
+import SettingsPage from "../settings/page";
+import { listDataSources, deleteDataSource } from "@/lib/api";
+import type { DataSource } from "@/types/report";
+
+const mockSource: DataSource = {
+  id: "1",
+  user_id: "u1",
+  provider: "google",
+  expires_at: "2026-12-31T00:00:00Z",
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-04-01T00:00:00Z",
+};
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches data sources on mount and shows connected state", async () => {
+    vi.mocked(listDataSources).mockResolvedValue([mockSource]);
+
+    render(<SettingsPage />);
+
+    expect(listDataSources).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByRole("button", { name: "切断" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("接続済み")).toBeInTheDocument();
+  });
+
+  it("calls deleteDataSource and refetches when disconnect is clicked", async () => {
+    vi.mocked(listDataSources).mockResolvedValue([mockSource]);
+    vi.mocked(deleteDataSource).mockResolvedValue({ status: "deleted" });
+
+    render(<SettingsPage />);
+
+    const disconnect = await screen.findByRole("button", { name: "切断" });
+    fireEvent.click(disconnect);
+
+    await waitFor(() =>
+      expect(deleteDataSource).toHaveBeenCalledWith("google"),
+    );
+    // one initial load + one refetch after disconnect
+    await waitFor(() => expect(listDataSources).toHaveBeenCalledTimes(2));
+  });
+
+  it("surfaces an error when the fetch fails", async () => {
+    vi.mocked(listDataSources).mockRejectedValue(new Error("認証が必要です"));
+
+    render(<SettingsPage />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("認証が必要です");
+  });
+});

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -1,17 +1,93 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import type { ReportType } from "@/types/report";
+import { ReportEditor } from "@/components/report-editor";
+import { ReportList } from "@/components/report-list";
+import { generateReport, listReports, updateReport } from "@/lib/api";
+import type { Report, ReportType } from "@/types/report";
+
+const tabs: { type: ReportType; label: string }[] = [
+  { type: "daily", label: "日報" },
+  { type: "weekly", label: "週報" },
+  { type: "monthly", label: "月報" },
+];
+
+const generateLabels: Record<ReportType, string> = {
+  daily: "日報を生成",
+  weekly: "週報を生成",
+  monthly: "月報を生成",
+};
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 export default function ReportsPage() {
   const [selectedType, setSelectedType] = useState<ReportType>("daily");
+  const [reports, setReports] = useState<Report[]>([]);
+  const [selected, setSelected] = useState<Report | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const tabs: { type: ReportType; label: string }[] = [
-    { type: "daily", label: "日報" },
-    { type: "weekly", label: "週報" },
-    { type: "monthly", label: "月報" },
-  ];
+  const loadReports = useCallback(async (type: ReportType) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await listReports(type);
+      setReports(list ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "レポートの取得に失敗しました");
+      setReports([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setSelected(null);
+    void loadReports(selectedType);
+  }, [selectedType, loadReports]);
+
+  const handleGenerate = async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      const report = await generateReport({
+        type: selectedType,
+        date: today(),
+      });
+      await loadReports(selectedType);
+      setSelected(report);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "レポートの生成に失敗しました");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleSave = async (content: string, status: string) => {
+    if (!selected) return;
+    setError(null);
+    try {
+      await updateReport(selected.id, { content, status });
+      await loadReports(selectedType);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "保存に失敗しました");
+    }
+  };
+
+  const handleSend = async (content: string) => {
+    if (!selected) return;
+    setError(null);
+    try {
+      await updateReport(selected.id, { content, status: "sent" });
+      await loadReports(selectedType);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "送信に失敗しました");
+    }
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -48,19 +124,51 @@ export default function ReportsPage() {
               </button>
             ))}
           </div>
-          <button className="rounded-lg bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700">
-            {selectedType === "daily"
-              ? "日報を生成"
-              : selectedType === "weekly"
-                ? "週報を生成"
-                : "月報を生成"}
+          <button
+            onClick={handleGenerate}
+            disabled={generating}
+            className="rounded-lg bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700 disabled:opacity-50"
+          >
+            {generating ? "生成中..." : generateLabels[selectedType]}
           </button>
         </div>
 
-        <div className="rounded-lg border border-gray-200 bg-white p-6">
-          <p className="text-center text-gray-500">
-            データソースを接続してレポートを生成してください
-          </p>
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="grid gap-6 md:grid-cols-[320px_1fr]">
+          <div className="rounded-lg border border-gray-200 bg-white p-4">
+            {loading ? (
+              <p className="py-8 text-center text-gray-500">読み込み中...</p>
+            ) : (
+              <ReportList
+                reports={reports}
+                onSelect={setSelected}
+                selectedId={selected?.id}
+              />
+            )}
+          </div>
+
+          <div className="rounded-lg border border-gray-200 bg-white p-6">
+            {selected ? (
+              <ReportEditor
+                key={selected.id}
+                report={selected}
+                onSave={handleSave}
+                onSend={handleSend}
+              />
+            ) : (
+              <p className="py-8 text-center text-gray-500">
+                レポートを選択するか、「{generateLabels[selectedType]}」で新しく作成してください
+              </p>
+            )}
+          </div>
         </div>
       </main>
     </div>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,12 +1,37 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { DataSourceSettings } from "@/components/datasource-settings";
-import { deleteDataSource } from "@/lib/api";
+import { deleteDataSource, listDataSources } from "@/lib/api";
 import { oauthConnectUrl } from "@/lib/backend";
-import type { Provider } from "@/types/report";
+import type { DataSource, Provider } from "@/types/report";
 
 export default function SettingsPage() {
+  const [dataSources, setDataSources] = useState<DataSource[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadDataSources = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const sources = await listDataSources();
+      setDataSources(sources ?? []);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "データソースの取得に失敗しました",
+      );
+      setDataSources([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadDataSources();
+  }, [loadDataSources]);
+
   const handleConnect = (provider: Provider) => {
     // Absolute URL to the backend origin — a relative URL would resolve against
     // the frontend origin (:3000) and 404.
@@ -14,9 +39,13 @@ export default function SettingsPage() {
   };
 
   const handleDisconnect = async (provider: Provider) => {
-    await deleteDataSource(provider);
-    // Reload so the datasource list reflects the disconnected state.
-    window.location.reload();
+    setError(null);
+    try {
+      await deleteDataSource(provider);
+      await loadDataSources();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "切断に失敗しました");
+    }
   };
 
   return (
@@ -40,12 +69,25 @@ export default function SettingsPage() {
       <main className="mx-auto max-w-6xl px-6 py-8">
         <h1 className="mb-6 text-2xl font-bold">設定</h1>
 
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          >
+            {error}
+          </div>
+        )}
+
         <div className="rounded-lg border border-gray-200 bg-white p-6">
-          <DataSourceSettings
-            dataSources={[]}
-            onConnect={handleConnect}
-            onDisconnect={handleDisconnect}
-          />
+          {loading ? (
+            <p className="py-8 text-center text-gray-500">読み込み中...</p>
+          ) : (
+            <DataSourceSettings
+              dataSources={dataSources}
+              onConnect={handleConnect}
+              onDisconnect={handleDisconnect}
+            />
+          )}
         </div>
       </main>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -81,11 +81,14 @@ export async function listActivities(date: string): Promise<Activity[]> {
   return fetchAPI<Activity[]>(`/activities?date=${date}`);
 }
 
-export async function collectActivities(): Promise<{
+export interface CollectResult {
   status: string;
-  message: string;
-}> {
-  return fetchAPI<{ status: string; message: string }>("/activities/collect", {
+  collected: number;
+  errors: number;
+}
+
+export async function collectActivities(): Promise<CollectResult> {
+  return fetchAPI<CollectResult>("/activities/collect", {
     method: "POST",
   });
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,8 +1,16 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    // Mirror the "@/*" -> "./src/*" path alias from tsconfig.json so runtime
+    // (non-type) imports resolve in tests the same way they do under Next.js.
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## 概要
画面にデータが表示されない問題と、データ取得ロジックの不具合を修正。設定/レポート画面を実際に API と接続し、Gmail のタイムスタンプと週報/月報の取得範囲を正す。

## 変更内容
| Issue | 内容 |
|-------|------|
| #20 | 設定画面: `useEffect`/`useState` で `listDataSources()` を取得し表示、切断後は一覧を再取得。レポート画面: 「生成」ボタンに `onClick`（`generateReport`）を実装し、`listReports` の一覧・`ReportEditor` での編集/保存/送信を接続。ページテストのため vitest に `@` エイリアスを追加 |
| #25 | Gmail の `internalDate`（Unix ミリ秒）を `strconv.ParseInt`+`time.UnixMilli` で変換。`time.Now()` ハードコードを解消（パース不能時のみ現在時刻にフォールバック） |
| #26 | フロントの `collectActivities` 戻り型をバックエンドの実レスポンス `{status, collected, errors}` に一致 |
| #28 | `ListReportsByUserAndDateRange` を追加し、週報/月報の要約で日付範囲クエリを使用。最新7件のみ取得する制限を撤廃し、過去の週/月を遡って取得可能に |

## 設計メモ
- #28 に伴い `summary.Service` を `reportRepository`/`summarizerClient` インターフェース依存に変更。DB/Anthropic なしでユニットテスト可能にし、`*repository.Repository`・`*Summarizer` はそのまま満たす（`main.go` 配線は #24 で実施）。

## テスト
- backend: Gmail タイムスタンプ変換（テーブル駆動）、週報/月報生成（fake で日付範囲・7件制限撤廃・日報フォールバックを検証）
- frontend: 設定/レポート各ページの結合テスト（マウント時取得・生成ボタン・切断・タイプ切替）
- `go test -race ./...` green / `pnpm lint && pnpm test (18) && pnpm build` green / gofmt・goimports クリーン

## 補足
- `summary.Service` は本 PR 時点では未配線（デッドコードのまま）。`main.go` への配線と HTTP ルート追加は #24（グループ3）で対応。
- `vitest.config.ts` の変更はテスト用エイリアス追加のみ（lint 設定には未変更）。

Fixes #20
Fixes #25
Fixes #26
Fixes #28