### PR TITLE
fix(security,quality): SameSite cookie, PII masking, summary wiring, lint/tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ DB_PORT=5432
 DB_USER=shigoto
 DB_PASSWORD=shigoto_dev
 DB_NAME=shigoto_flow
+# PostgreSQL sslmode: disable (local), require/verify-full (production)
+DB_SSLMODE=disable
 
 # Google OAuth2
 GOOGLE_CLIENT_ID=
@@ -29,3 +31,11 @@ JWT_SECRET=
 # Server
 PORT=8080
 FRONTEND_URL=http://localhost:3000
+# Public origin of this backend, used to build OAuth redirect URIs
+BACKEND_URL=http://localhost:8080
+# Session cookie SameSite policy: lax (default, same-site safe), strict, or none
+# (none requires HTTPS). Use lax unless the frontend is on a different site.
+COOKIE_SAME_SITE=lax
+
+# Frontend (Next.js) environment variables live in frontend/.env.example
+# (NEXT_PUBLIC_API_URL, NEXT_PUBLIC_BACKEND_URL).

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -4,15 +4,14 @@ run:
   timeout: 5m
 
 linters:
+  # gofmt/goimports are configured under "formatters" (golangci-lint v2 treats
+  # them as formatters, not linters). gosimple was merged into staticcheck in v2.
   enable:
     - errcheck
     - govet
     - staticcheck
     - unused
-    - gosimple
     - ineffassign
-    - gofmt
-    - goimports
 
 formatters:
   enable:

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/akaitigo/shigoto-flow/backend/internal/handler"
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 	"github.com/akaitigo/shigoto-flow/backend/internal/repository"
+	"github.com/akaitigo/shigoto-flow/backend/internal/summary"
 )
 
 func main() {
@@ -30,7 +31,7 @@ func main() {
 		slog.Error("failed to connect to database", "error", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	if cfg.TokenEncryptionKey == "" {
 		slog.Error("TOKEN_ENCRYPTION_KEY is required (32 bytes)")
@@ -75,12 +76,18 @@ func main() {
 	)
 	collSvc := collector.NewService(repo, coll, encryptor)
 
+	// Weekly/monthly AI summarization (F3). Requires ANTHROPIC_API_KEY at call
+	// time; the endpoint returns an error if the key is unset.
+	summarizer := summary.New(cfg.Anthropic.APIKey, nil)
+	summarySvc := summary.NewService(repo, summarizer)
+
 	// Start periodic cleanup of expired OAuth state entries (every 5 minutes)
 	cleanupCancel := oauthMgr.StartStateCleanup(context.Background(), 5*time.Minute)
 	defer cleanupCancel()
 
 	h := handler.New(repo, cfg, oauthMgr, encryptor)
 	h.SetCollectorService(collSvc)
+	h.SetSummaryService(summarySvc)
 	router := h.Routes()
 
 	srv := &http.Server{

--- a/backend/internal/auth/oauth.go
+++ b/backend/internal/auth/oauth.go
@@ -153,7 +153,7 @@ func (m *OAuthManager) ExchangeCode(ctx context.Context, provider model.Provider
 	if err != nil {
 		return nil, fmt.Errorf("failed to exchange code: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -205,7 +205,7 @@ func (m *OAuthManager) RefreshToken(ctx context.Context, provider model.Provider
 	if err != nil {
 		return nil, fmt.Errorf("failed to refresh token: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -278,7 +278,7 @@ func (m *OAuthManager) FetchUserInfo(ctx context.Context, provider model.Provide
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch userinfo: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/backend/internal/collector/github.go
+++ b/backend/internal/collector/github.go
@@ -44,7 +44,7 @@ func (g *GitHubSource) Collect(ctx context.Context, accessToken string, date tim
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch github events: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/backend/internal/collector/gmail.go
+++ b/backend/internal/collector/gmail.go
@@ -54,7 +54,7 @@ func (g *GmailSource) Collect(ctx context.Context, accessToken string, date time
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch gmail messages: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -113,7 +113,7 @@ func (g *GmailSource) getMessageDetail(ctx context.Context, accessToken, message
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch message detail: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/backend/internal/collector/google_calendar.go
+++ b/backend/internal/collector/google_calendar.go
@@ -51,7 +51,7 @@ func (g *GoogleCalendarSource) Collect(ctx context.Context, accessToken string, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch calendar events: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/backend/internal/collector/service.go
+++ b/backend/internal/collector/service.go
@@ -87,7 +87,7 @@ func (s *Service) CollectForUser(ctx context.Context, userID string, date time.T
 	}
 
 	go func() {
-		g.Wait()
+		_ = g.Wait()
 		close(results)
 	}()
 

--- a/backend/internal/collector/slack.go
+++ b/backend/internal/collector/slack.go
@@ -49,7 +49,7 @@ func (s *SlackSource) Collect(ctx context.Context, accessToken string, date time
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch slack messages: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	BackendURL         string
 	TokenEncryptionKey string
 	JWTSecret          string
+	CookieSameSite     string
 	DB                 DBConfig
 	Google             OAuthConfig
 	Slack              OAuthConfig
@@ -61,6 +62,10 @@ func Load() (*Config, error) {
 		BackendURL:         getEnv("BACKEND_URL", "http://localhost:8080"),
 		TokenEncryptionKey: os.Getenv("TOKEN_ENCRYPTION_KEY"),
 		JWTSecret:          os.Getenv("JWT_SECRET"),
+		// Default to Lax: sufficient for same-site frontend/backend deployments
+		// and safer against CSRF than None. Set to "none" only for genuine
+		// cross-site setups (requires HTTPS).
+		CookieSameSite: getEnv("COOKIE_SAME_SITE", "lax"),
 		DB: DBConfig{
 			Host:     getEnv("DB_HOST", "localhost"),
 			Port:     dbPort,

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -24,6 +24,27 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.DB.Port != 5432 {
 		t.Errorf("expected DB port 5432, got %d", cfg.DB.Port)
 	}
+
+	if cfg.CookieSameSite != "lax" {
+		t.Errorf("expected default cookie SameSite lax, got %q", cfg.CookieSameSite)
+	}
+
+	if cfg.DB.SSLMode != "disable" {
+		t.Errorf("expected default DB SSLMode disable, got %q", cfg.DB.SSLMode)
+	}
+}
+
+func TestLoad_CookieSameSiteOverride(t *testing.T) {
+	t.Setenv("COOKIE_SAME_SITE", "strict")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.CookieSameSite != "strict" {
+		t.Errorf("expected cookie SameSite strict, got %q", cfg.CookieSameSite)
+	}
 }
 
 func TestLoad_CustomPort(t *testing.T) {

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -64,7 +64,7 @@ func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 	// Look up existing user by email, or create a new one
 	existingUser, err := h.repo.GetUserByEmail(r.Context(), userInfo.Email)
 	if err != nil {
-		slog.Error("failed to look up user by email", "email", userInfo.Email, "error", err)
+		slog.Error("failed to look up user by email", "email", maskEmail(userInfo.Email), "error", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to look up user")
 		return
 	}
@@ -139,9 +139,11 @@ func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 	// Set JWT as HttpOnly cookie instead of URL query parameter (RFC 6750 compliance)
 	frontendURL, parseErr := url.Parse(h.cfg.FrontendURL)
 	isSecure := parseErr == nil && frontendURL.Scheme == "https"
-	sameSite := http.SameSiteLaxMode
-	if isSecure {
-		sameSite = http.SameSiteNoneMode
+	sameSite := parseSameSite(h.cfg.CookieSameSite)
+	// SameSite=None is only valid on Secure cookies; downgrade to Lax over
+	// plain HTTP so the browser doesn't reject the cookie outright.
+	if sameSite == http.SameSiteNoneMode && !isSecure {
+		sameSite = http.SameSiteLaxMode
 	}
 
 	http.SetCookie(w, &http.Cookie{
@@ -171,6 +173,31 @@ func cookieDomain(rawURL string) string {
 		return ""
 	}
 	return host
+}
+
+// maskEmail redacts the local part of an email address so it can be logged
+// without exposing PII, keeping only the domain for debugging context
+// (e.g. "user@example.com" -> "***@example.com"). Values that are not
+// email-shaped are fully redacted.
+func maskEmail(email string) string {
+	at := strings.LastIndex(email, "@")
+	if at <= 0 || at == len(email)-1 {
+		return "***"
+	}
+	return "***@" + email[at+1:]
+}
+
+// parseSameSite maps a COOKIE_SAME_SITE string to an http.SameSite mode.
+// Unknown or empty values fall back to Lax, the safer default.
+func parseSameSite(value string) http.SameSite {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "strict":
+		return http.SameSiteStrictMode
+	case "none":
+		return http.SameSiteNoneMode
+	default:
+		return http.SameSiteLaxMode
+	}
 }
 
 // isValidProvider checks whether the given provider is supported.

--- a/backend/internal/handler/auth_test.go
+++ b/backend/internal/handler/auth_test.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestMaskEmail(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		{name: "typical address", email: "user@example.com", want: "***@example.com"},
+		{name: "subdomain", email: "a.b@mail.corp.example", want: "***@mail.corp.example"},
+		{name: "empty", email: "", want: "***"},
+		{name: "no at sign", email: "notanemail", want: "***"},
+		{name: "at start", email: "@example.com", want: "***"},
+		{name: "at end", email: "user@", want: "***"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskEmail(tt.email)
+			if got != tt.want {
+				t.Errorf("maskEmail(%q) = %q, want %q", tt.email, got, tt.want)
+			}
+			// The masked value must never contain the local part of the address.
+			if local, _, ok := strings.Cut(tt.email, "@"); ok && local != "" {
+				if strings.Contains(got, local) {
+					t.Errorf("masked value %q leaked local part %q", got, local)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSameSite(t *testing.T) {
+	tests := []struct {
+		value string
+		want  http.SameSite
+	}{
+		{"lax", http.SameSiteLaxMode},
+		{"Lax", http.SameSiteLaxMode},
+		{"strict", http.SameSiteStrictMode},
+		{"STRICT", http.SameSiteStrictMode},
+		{"none", http.SameSiteNoneMode},
+		{" none ", http.SameSiteNoneMode},
+		{"", http.SameSiteLaxMode},
+		{"garbage", http.SameSiteLaxMode},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			if got := parseSameSite(tt.value); got != tt.want {
+				t.Errorf("parseSameSite(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -18,6 +18,7 @@ type Handler struct {
 	oauth        *auth.OAuthManager
 	encryptor    *auth.TokenEncryptor
 	collectorSvc *collector.Service
+	summarySvc   summaryService
 }
 
 func New(repo *repository.Repository, cfg *config.Config, oauth *auth.OAuthManager, encryptor *auth.TokenEncryptor) *Handler {
@@ -26,6 +27,10 @@ func New(repo *repository.Repository, cfg *config.Config, oauth *auth.OAuthManag
 
 func (h *Handler) SetCollectorService(svc *collector.Service) {
 	h.collectorSvc = svc
+}
+
+func (h *Handler) SetSummaryService(svc summaryService) {
+	h.summarySvc = svc
 }
 
 func (h *Handler) Routes() http.Handler {
@@ -37,6 +42,7 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("GET /api/v1/reports/{id}", h.GetReport)
 	mux.HandleFunc("PUT /api/v1/reports/{id}", h.UpdateReport)
 	mux.HandleFunc("POST /api/v1/reports/generate", h.GenerateReport)
+	mux.HandleFunc("POST /api/v1/reports/summarize", h.SummarizeReport)
 	mux.HandleFunc("GET /api/v1/activities", h.ListActivities)
 	mux.HandleFunc("POST /api/v1/activities/collect", h.CollectActivities)
 	mux.HandleFunc("GET /api/v1/templates", h.ListTemplates)

--- a/backend/internal/handler/summarize.go
+++ b/backend/internal/handler/summarize.go
@@ -1,0 +1,84 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
+	"github.com/akaitigo/shigoto-flow/backend/internal/model"
+	"github.com/akaitigo/shigoto-flow/backend/internal/summary"
+)
+
+// summaryService produces AI summaries (weekly/monthly) from stored reports.
+// It is an interface so the handler can be tested without a live database or
+// Claude API; *summary.Service satisfies it.
+type summaryService interface {
+	GenerateWeeklySummary(ctx context.Context, userID string, weekStart time.Time) (string, error)
+	GenerateMonthlySummary(ctx context.Context, userID string, month time.Time) (string, error)
+}
+
+type summarizeRequest struct {
+	Type model.ReportType `json:"type"`
+	Date string           `json:"date"`
+}
+
+type summarizeResponse struct {
+	Type    model.ReportType `json:"type"`
+	Date    string           `json:"date"`
+	Content string           `json:"content"`
+}
+
+// SummarizeReport generates a weekly or monthly AI summary from the user's
+// existing reports for the period containing the given date.
+func (h *Handler) SummarizeReport(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing user ID")
+		return
+	}
+
+	if h.summarySvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "summary service not configured")
+		return
+	}
+
+	var req summarizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		return
+	}
+
+	if req.Type != model.ReportTypeWeekly && req.Type != model.ReportTypeMonthly {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "type must be weekly or monthly")
+		return
+	}
+
+	date, err := time.Parse("2006-01-02", req.Date)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "invalid date format, use YYYY-MM-DD")
+		return
+	}
+
+	var content string
+	switch req.Type {
+	case model.ReportTypeWeekly:
+		content, err = h.summarySvc.GenerateWeeklySummary(r.Context(), userID, date)
+	case model.ReportTypeMonthly:
+		content, err = h.summarySvc.GenerateMonthlySummary(r.Context(), userID, date)
+	}
+	if err != nil {
+		if errors.Is(err, summary.ErrNoReports) {
+			writeError(w, http.StatusUnprocessableEntity, "NO_REPORTS", "no reports available to summarize for this period")
+			return
+		}
+		slog.Error("failed to generate summary", "type", req.Type, "error", err)
+		writeError(w, http.StatusInternalServerError, "SUMMARY_FAILED", "failed to generate summary")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, summarizeResponse{Type: req.Type, Date: req.Date, Content: content})
+}

--- a/backend/internal/handler/summarize_test.go
+++ b/backend/internal/handler/summarize_test.go
@@ -1,0 +1,161 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/akaitigo/shigoto-flow/backend/internal/middleware"
+	"github.com/akaitigo/shigoto-flow/backend/internal/summary"
+)
+
+type fakeSummaryService struct {
+	weekly    string
+	monthly   string
+	weeklyErr error
+	monthErr  error
+	called    string
+	gotUserID string
+	gotDate   time.Time
+}
+
+func (f *fakeSummaryService) GenerateWeeklySummary(_ context.Context, userID string, weekStart time.Time) (string, error) {
+	f.called = "weekly"
+	f.gotUserID = userID
+	f.gotDate = weekStart
+	return f.weekly, f.weeklyErr
+}
+
+func (f *fakeSummaryService) GenerateMonthlySummary(_ context.Context, userID string, month time.Time) (string, error) {
+	f.called = "monthly"
+	f.gotUserID = userID
+	f.gotDate = month
+	return f.monthly, f.monthErr
+}
+
+func doSummarize(h *Handler, body string, authed bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reports/summarize", strings.NewReader(body))
+	if authed {
+		req = req.WithContext(middleware.WithUserID(req.Context(), "user-1"))
+	}
+	rec := httptest.NewRecorder()
+	h.SummarizeReport(rec, req)
+	return rec
+}
+
+func TestSummarizeReport_Weekly(t *testing.T) {
+	fake := &fakeSummaryService{weekly: "今週のまとめ"}
+	h := &Handler{summarySvc: fake}
+
+	rec := doSummarize(h, `{"type":"weekly","date":"2026-04-06"}`, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	var resp summarizeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Content != "今週のまとめ" {
+		t.Errorf("expected weekly content, got %q", resp.Content)
+	}
+	if fake.called != "weekly" {
+		t.Errorf("expected weekly generator called, got %q", fake.called)
+	}
+	if fake.gotUserID != "user-1" {
+		t.Errorf("expected user-1, got %q", fake.gotUserID)
+	}
+	if want := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC); !fake.gotDate.Equal(want) {
+		t.Errorf("expected date %v, got %v", want, fake.gotDate)
+	}
+}
+
+func TestSummarizeReport_Monthly(t *testing.T) {
+	fake := &fakeSummaryService{monthly: "今月のまとめ"}
+	h := &Handler{summarySvc: fake}
+
+	rec := doSummarize(h, `{"type":"monthly","date":"2026-04-01"}`, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if fake.called != "monthly" {
+		t.Errorf("expected monthly generator called, got %q", fake.called)
+	}
+}
+
+func TestSummarizeReport_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		svc      summaryService
+		body     string
+		authed   bool
+		wantCode int
+	}{
+		{
+			name:     "unauthenticated",
+			svc:      &fakeSummaryService{},
+			body:     `{"type":"weekly","date":"2026-04-06"}`,
+			authed:   false,
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "invalid type daily",
+			svc:      &fakeSummaryService{},
+			body:     `{"type":"daily","date":"2026-04-06"}`,
+			authed:   true,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid date",
+			svc:      &fakeSummaryService{},
+			body:     `{"type":"weekly","date":"nope"}`,
+			authed:   true,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "malformed json",
+			svc:      &fakeSummaryService{},
+			body:     `{`,
+			authed:   true,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "no reports",
+			svc:      &fakeSummaryService{weeklyErr: summary.ErrNoReports},
+			body:     `{"type":"weekly","date":"2026-04-06"}`,
+			authed:   true,
+			wantCode: http.StatusUnprocessableEntity,
+		},
+		{
+			name:     "generation failure",
+			svc:      &fakeSummaryService{weeklyErr: errors.New("claude down")},
+			body:     `{"type":"weekly","date":"2026-04-06"}`,
+			authed:   true,
+			wantCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handler{summarySvc: tt.svc}
+			rec := doSummarize(h, tt.body, tt.authed)
+			if rec.Code != tt.wantCode {
+				t.Errorf("expected %d, got %d (%s)", tt.wantCode, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestSummarizeReport_ServiceNotConfigured(t *testing.T) {
+	h := &Handler{} // summarySvc is nil
+	rec := doSummarize(h, `{"type":"weekly","date":"2026-04-06"}`, true)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when summary service is unset, got %d", rec.Code)
+	}
+}

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -30,7 +30,7 @@ func AuthWithSecret(secret []byte) func(http.Handler) http.Handler {
 				return
 			}
 
-			ctx := context.WithValue(r.Context(), userIDKey, claims.UserID)
+			ctx := WithUserID(r.Context(), claims.UserID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -47,6 +47,13 @@ func extractToken(r *http.Request) string {
 		return strings.TrimPrefix(authHeader, "Bearer ")
 	}
 	return ""
+}
+
+// WithUserID returns a copy of ctx that carries the given user ID. It is the
+// counterpart to UserIDFromContext, used by the auth middleware and by tests
+// that need to simulate an authenticated request.
+func WithUserID(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, userIDKey, userID)
 }
 
 func UserIDFromContext(ctx context.Context) string {

--- a/backend/internal/report/generator.go
+++ b/backend/internal/report/generator.go
@@ -47,19 +47,19 @@ func (g *Generator) Generate(ctx context.Context, userID string, tmpl *model.Tem
 func renderReport(tmpl *model.Template, activities []model.Activity, date time.Time, reportType model.ReportType) string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("# %s — %s\n\n", reportTypeLabel(reportType), date.Format("2006-01-02")))
+	fmt.Fprintf(&sb, "# %s — %s\n\n", reportTypeLabel(reportType), date.Format("2006-01-02"))
 
 	grouped := groupBySource(activities)
 
 	for _, section := range tmpl.Sections {
-		sb.WriteString(fmt.Sprintf("## %s\n\n", section.Title))
+		fmt.Fprintf(&sb, "## %s\n\n", section.Title)
 
 		switch section.Title {
 		case "やったこと":
 			for source, acts := range grouped {
-				sb.WriteString(fmt.Sprintf("### %s\n", sourceLabel(source)))
+				fmt.Fprintf(&sb, "### %s\n", sourceLabel(source))
 				for _, a := range acts {
-					sb.WriteString(fmt.Sprintf("- %s\n", a.Title))
+					fmt.Fprintf(&sb, "- %s\n", a.Title)
 				}
 				sb.WriteString("\n")
 			}

--- a/backend/internal/repository/activity.go
+++ b/backend/internal/repository/activity.go
@@ -38,7 +38,7 @@ func (r *Repository) ListActivitiesByUserAndDate(ctx context.Context, userID str
 	if err != nil {
 		return nil, fmt.Errorf("failed to list activities: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var activities []model.Activity
 	for rows.Next() {
@@ -66,7 +66,7 @@ func (r *Repository) ListActivitiesByUserAndRange(ctx context.Context, userID st
 	if err != nil {
 		return nil, fmt.Errorf("failed to list activities by range: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var activities []model.Activity
 	for rows.Next() {

--- a/backend/internal/repository/datasource.go
+++ b/backend/internal/repository/datasource.go
@@ -59,7 +59,7 @@ func (r *Repository) ListDataSourcesByUser(ctx context.Context, userID string) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to list data sources: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var sources []model.DataSource
 	for rows.Next() {

--- a/backend/internal/repository/db.go
+++ b/backend/internal/repository/db.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	_ "github.com/lib/pq"
 
@@ -21,6 +22,9 @@ func NewDB(cfg config.DBConfig) (*sql.DB, error) {
 
 	db.SetMaxOpenConns(25)
 	db.SetMaxIdleConns(5)
+	// Recycle connections periodically so long-lived pooled connections don't
+	// become stale (e.g. dropped by the database or a proxy after idle time).
+	db.SetConnMaxLifetime(5 * time.Minute)
 
 	return db, nil
 }

--- a/backend/internal/repository/report.go
+++ b/backend/internal/repository/report.go
@@ -56,7 +56,7 @@ func (r *Repository) ListReportsByUser(ctx context.Context, userID string, repor
 	if err != nil {
 		return nil, fmt.Errorf("failed to list reports: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var reports []model.Report
 	for rows.Next() {
@@ -88,7 +88,7 @@ func (r *Repository) ListReportsByUserAndDateRange(ctx context.Context, userID s
 	if err != nil {
 		return nil, fmt.Errorf("failed to list reports by date range: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var reports []model.Report
 	for rows.Next() {

--- a/backend/internal/repository/template.go
+++ b/backend/internal/repository/template.go
@@ -64,7 +64,7 @@ func (r *Repository) ListTemplatesByUser(ctx context.Context, userID string) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to list templates: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var templates []model.Template
 	for rows.Next() {

--- a/backend/internal/sender/slack.go
+++ b/backend/internal/sender/slack.go
@@ -46,7 +46,7 @@ func (s *SlackSender) Send(ctx context.Context, to, subject, body string) error 
 	if err != nil {
 		return fmt.Errorf("failed to send slack message: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/backend/internal/summary/service.go
+++ b/backend/internal/summary/service.go
@@ -2,11 +2,17 @@ package summary
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/akaitigo/shigoto-flow/backend/internal/model"
 )
+
+// ErrNoReports indicates there were no source reports to summarize for the
+// requested period. Callers can treat this as a client-actionable condition
+// (the user needs to create reports first) rather than a server error.
+var ErrNoReports = errors.New("no reports found for the requested period")
 
 // reportRepository is the subset of the repository used by the summary service.
 // Using an interface keeps the service unit-testable without a live database.
@@ -44,7 +50,7 @@ func (s *Service) GenerateWeeklySummary(ctx context.Context, userID string, week
 	}
 
 	if len(dailyContents) == 0 {
-		return "", fmt.Errorf("no daily reports found for the specified week")
+		return "", fmt.Errorf("weekly summary: %w", ErrNoReports)
 	}
 
 	return s.summarizer.Summarize(ctx, SummarizeInput{
@@ -80,7 +86,7 @@ func (s *Service) GenerateMonthlySummary(ctx context.Context, userID string, mon
 	}
 
 	if len(contents) == 0 {
-		return "", fmt.Errorf("no reports found for the specified month")
+		return "", fmt.Errorf("monthly summary: %w", ErrNoReports)
 	}
 
 	return s.summarizer.Summarize(ctx, SummarizeInput{

--- a/backend/internal/summary/summarizer.go
+++ b/backend/internal/summary/summarizer.go
@@ -57,11 +57,11 @@ func (s *Summarizer) Summarize(ctx context.Context, input SummarizeInput) (strin
 	if err != nil {
 		return "", fmt.Errorf("failed to call Claude API: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("Claude API returned %d: %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("received status %d from Claude API: %s", resp.StatusCode, string(body))
 	}
 
 	var result struct {
@@ -96,7 +96,7 @@ func buildSystemPrompt(input SummarizeInput) string {
 func buildUserContent(input SummarizeInput) string {
 	var buf bytes.Buffer
 	for i, r := range input.Reports {
-		buf.WriteString(fmt.Sprintf("--- レポート %d ---\n%s\n\n", i+1, r))
+		fmt.Fprintf(&buf, "--- レポート %d ---\n%s\n\n", i+1, r)
 	}
 	return buf.String()
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Base URL of the Go API (used for fetch() calls). Include the /api/v1 prefix.
+NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
+
+# Base origin of the Go API (used for full-page OAuth connect redirects).
+NEXT_PUBLIC_BACKEND_URL=http://localhost:8080

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+# Lightweight pre-commit hooks.
+# Activate locally with `lefthook install`. Each command is scoped by glob so
+# only the checks relevant to the staged files run (e.g. Go checks are skipped
+# for a docs-only commit). Formatting is enforced by golangci-lint (gofmt /
+# goimports formatters) and eslint.
+pre-commit:
+  parallel: true
+  commands:
+    backend:
+      glob: "backend/**/*.go"
+      run: make lint-backend test-backend
+    frontend:
+      glob: "frontend/**/*.{ts,tsx,mjs}"
+      run: make lint-frontend test-frontend


### PR DESCRIPTION
## 概要
グループ3（セキュリティ + 品質）。CSRF リスクの低減、ログの PII マスキング、AI 要約機能の配線、DB/lint/pre-commit の整備をまとめて対応。

## 変更内容
| Issue | 内容 |
|-------|------|
| #22 | セッション Cookie の `SameSite` を `COOKIE_SAME_SITE` で制御可能にし、デフォルトを `Lax`（従来は HTTPS 時一律 `None`）に。`None` は Secure でない場合 `Lax` にダウングレード |
| #31 | エラーログのメールアドレスをマスク（`***@domain`）。ローカル部を漏らさない |
| #24 | `main.go` で summarizer/summary サービスを初期化し `POST /api/v1/reports/summarize`（weekly/monthly）を追加。テスト容易化のため `summaryService` インターフェース + `middleware.WithUserID` を導入。要約対象なし時は 422 を返す |
| #30 | DB `ConnMaxLifetime`（5分）を設定し stale 接続を回収 |
| #29 | golangci-lint v2 設定を修正（gofmt/goimports は formatter、gosimple は staticcheck へ統合）。**設定修正で表面化した既存の 19 件（errcheck 18 + staticcheck 1）も解消**し `make lint` を green 化 |
| #27 | 欠落していた環境変数を追記（`BACKEND_URL`, `DB_SSLMODE`, `COOKIE_SAME_SITE`）+ `frontend/.env.example` を新規作成（`.gitignore` に `!.env.example` 例外を追加） |
| #32 | 軽量な glob スコープの `lefthook.yml`（pre-commit で lint + test）を追加 |

## #29 の補足（レビュー注意点）
設定の重複を直すと golangci-lint がロード可能になり、これまで隠れていた既存の lint 違反 19 件が表面化しました（`defer x.Close()` / `g.Wait()` の未チェックエラー ×18、大文字始まりのエラーメッセージ ×1）。lint を実際に green にする（= #32 の lefthook が機能する）ため、これらも本 PR で解消しています。変更は機械的・安全（`defer func() { _ = x.Close() }()` 化、staticcheck 推奨の `fmt.Fprintf` 化、エラーメッセージ言い換え）で、挙動は不変です。そのため diff のファイル数が多くなっています。

## #24 の設計メモ
`/reports/summarize` は生成した要約テキストを返します（`{type, date, content}`）。既存 `/reports/generate`（テンプレート方式）とは別に、AI 要約（F3）を利用可能にするものです。永続化は既存のレポート保存フローに委ねます。

## テスト
- config: `COOKIE_SAME_SITE` / `DB_SSLMODE` の既定値・上書き
- handler: `maskEmail`（リーク検査付き）、`parseSameSite`、`SummarizeReport`（weekly/monthly 成功 + 400/401/422/500/503 を fake サービスで網羅）
- `go test -race ./...` green / `golangci-lint run ./...` **0 issues** / `make lint` green / gofmt・goimports クリーン
- `lefthook run pre-commit` で backend チェックが通ることを実機確認済み

Fixes #22
Fixes #24
Fixes #27
Fixes #29
Fixes #30
Fixes #31
Fixes #32