### PR TITLE
ci: update actions/checkout v4 to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v5
         with:
@@ -36,7 +36,7 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## 概要
actions/checkout を v4 から v7 に更新（Node.js 20 deprecation対応、期限2026-06-02の積み残し）。

## 破壊的変更の影響確認
- v5: Node 24化（GitHubホストランナーは対応済み）
- v6: 認証情報の別ファイル分離 → 本リポはcheckout認証に依存するstepなし
- v7: pull_request_target / workflow_run でのfork PRチェックアウト制限 → 本CIは push / pull_request トリガーのみ

## 検証
- actionlint パス
- YAML構文チェック パス